### PR TITLE
mergesort: Use queues to efficiently merge left and right sub-arrays.

### DIFF
--- a/src/sorting/mergesort.js
+++ b/src/sorting/mergesort.js
@@ -4,6 +4,8 @@
    */
   'use strict';
 
+  var ll = require('../data-structures/linked-list.js');
+
   function compare(a, b) {
     return a - b;
   }
@@ -61,8 +63,9 @@
    * }, 0, 4, 7);
    */
   mergeSort.merge = function (array, cmp, start, middle, end) {
-    var left = [];
-    var right = [];
+    var left = new ll.LinkedList();
+    var right = new ll.LinkedList();
+
     var leftSize = middle - start;
     var rightSize = end - middle;
     var maxSize = Math.max(leftSize, rightSize);
@@ -71,24 +74,24 @@
 
     for (i = 0; i < maxSize; i += 1) {
       if (i < leftSize) {
-        left[i] = array[start + i];
+        left.push(array[start + i]);
       }
       if (i < rightSize) {
-        right[i] = array[middle + i];
+        right.push(array[middle + i]);
       }
     }
     i = 0;
     while (i < size) {
-      if (left.length && right.length) {
-        if (cmp(left[0], right[0]) > 0) {
-          array[start + i] = right.shift();
+      if (left.first && right.first) {
+        if (cmp(left.first.data, right.first.data) > 0) {
+          array[start + i] = right.shift().data;
         } else {
-          array[start + i] = left.shift();
+          array[start + i] = left.shift().data;
         }
-      } else if (left.length) {
-        array[start + i] = left.shift();
+      } else if (left.first) {
+        array[start + i] = left.shift().data;
       } else {
-        array[start + i] = right.shift();
+        array[start + i] = right.shift().data;
       }
       i += 1;
     }


### PR DESCRIPTION
First of all, thanks for sharing this repo and for keeping it updated, you are awesome!

After tinkering with `mergeSort` I noticed that its time performance sharply degrades when we pass a certain input size threshold, just like you have described on your [blog post](http://blog.mgechev.com/2012/11/24/javascript-sorting-performance-quicksort-v8/).

It seems that the main culprit is the `Array.prototype.shift()` method that is used when merging `left` and `right` subarrays in `mergeSort.merge()`. A quick inspection of the `Array.prototype.shift()` [method specification](http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.shift) reveals that this operation takes O(N) time. The `right.shift()` and `left.shift()` operations are nested within a while loop that runs through all elemens of the subarrays. Therefore we don't have an O(n * logn) algorithm but  one that seems to be quadratic.

Instead of arrays, I propose using the working `LinkedList` data structure to implement a queue ADT and thus spend O(1) instead of O(N) for the same operation. Running a performance [test](https://gist.github.com/lekkas/d6a77ae22c78e476656e) with this approach on an unsorted array of 1M elements dropped the execution time from **8m 39.435s** to **0.802s** (~650x). More detailed results are [here](https://gist.github.com/lekkas/219c828fd31ca49b4a3b).

Moral of the story: Repeatedly calling `Array.prototype.shift()` on big data sets can really hurt performance.