### PR TITLE
Convert code from insertion sort logic to bubble sort

### DIFF
--- a/src/sorting/bubblesort.js
+++ b/src/sorting/bubblesort.js
@@ -25,12 +25,12 @@
   function bubbleSort(array, cmp) {
     cmp = cmp || comparator;
     var temp;
-    for (var i = 0; i < array.length; i += 1) {
-      for (var j = i; j > 0; j -= 1) {
-        if (cmp(array[j], array[j - 1]) < 0) {
+    for (var i = 0; i < array.length - 1; i += 1) {
+      for (var j = 0; j < array.length - 1 - i; j += 1) {
+        if (cmp(array[j + 1], array[j]) < 0) {
           temp = array[j];
-          array[j] = array[j - 1];
-          array[j - 1] = temp;
+          array[j] = array[j + 1];
+          array[j + 1] = temp;
         }
       }
     }


### PR DESCRIPTION
Collection elements should bubble up to the right in a bubble sort.
The compares should be made with all elements to the right.
In an insertion sort elements will sink towards the left and
compares are made with all elements to the left.

Please see step by step compares: https://en.wikipedia.org/wiki/Bubble_sort
