### PR TITLE
New nodes should be added with a max value (Fixes Issue #112)

### DIFF
--- a/src/data-structures/interval-tree.js
+++ b/src/data-structures/interval-tree.js
@@ -76,6 +76,7 @@
 
   function addNode(node, side, interval) {
     var child = new exports.Node(interval[0], interval[1]);
+    child.max = interval[1];
     child.parentNode = node;
     node[side] = child;
     if (node.max < interval[1]) {
@@ -113,6 +114,7 @@
   exports.IntervalTree.prototype.add = function (interval) {
     if (!this.root) {
       this.root = new exports.Node(interval[0], interval[1]);
+      this.root.max = interval[1];
       return;
     }
     addHelper(this.root, interval);

--- a/test/data-structures/interval-tree.spec.js
+++ b/test/data-structures/interval-tree.spec.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var mod = require('../../src/data-structures/interval-tree.js');
+var IntervalTree = mod.IntervalTree;
+
+describe('IntervalTree', function () {
+  it('should correctly detect intersections', function () {
+    var it = new IntervalTree();
+
+    it.add([10383734, 10594186])
+    it.add([10383734, 10594186])
+    it.add([8891125, 9095610])
+    it.add([9495571, 9677853])
+    it.add([10093457, 10257167])
+    it.add([9303743, 9404967])
+    it.intersects([9303743, 9303744])
+    expect(it.intersects([9303743, 9303744])).toBe(true)
+    expect(it.intersects([10383734, 10383734])).toBe(true);
+
+    it.add([9495571, 9677853])
+    it.add([9303743, 9404967])
+
+    expect(it.intersects([9303743, 9303744])).toBe(true)
+    expect(it.intersects([9303742, 9303742])).toBe(false)
+
+    expect(it.intersects([9404967,9404967 ])).toBe(true)
+    expect(it.intersects([9404968,9404969 ])).toBe(false)
+
+    it = new IntervalTree();
+
+    expect(it.intersects([1,2])).toBe(false);
+
+    it.add([1,2]);
+    expect(it.contains(0.4)).toBe(false);
+    expect(it.contains(1.4)).toBe(true);
+
+    expect(it.intersects([0,3])).toBe(true);
+    expect(it.intersects([1.5,1.6])).toBe(true);
+    expect(it.intersects([2.1,3.0])).toBe(false);
+
+    it.add([1.4,2.1]);
+
+    expect(it.intersects([0,3])).toBe(true);
+    expect(it.intersects([1.5,1.6])).toBe(true);
+
+    expect(it.intersects([2.1,3.0])).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR should fix Issue #112. 

Assuming the algorithm used is the one described in Cormon, Leirserson, Rivest book, each node (x) added to the interval tree should be assigned a max value (max[int[x]]) as well as an interval (int[x]). The previous version was assigning a max value of -Infinity, rather than max[int[x]].