### PR TITLE
Begin moving to ES6 syntax via linting changes.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,7 @@
     "no-empty": 2,
     "no-plusplus": 2,
     "no-undef": 2,
+    "no-var": 2,
     "linebreak-style": 0,
     "max-depth": [
       2,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "gulp build",
+    "lint": "gulp lint",
     "test": "gulp test",
     "deploy": "npm run doc:build && gh-pages -d dist -b gh-pages",
     "doc": "npm run doc:build && npm run doc:view",

--- a/src/combinatorics/cartesianproduct.js
+++ b/src/combinatorics/cartesianproduct.js
@@ -1,14 +1,14 @@
 (function (exports) {
   'use strict';
 
-  var cartesianProduct = (function () {
-    var result;
+  let cartesianProduct = (function () {
+    let result;
 
     function cartesianProduct(sets, index, current) {
       if (index === sets.length) {
         return result.push(current.slice());
       }
-      for (var i = 0; i < sets[index].length; i += 1) {
+      for (let i = 0; i < sets[index].length; i += 1) {
         current[index] = sets[index][i];
         cartesianProduct(sets, index + 1, current);
       }

--- a/src/combinatorics/combinations.js
+++ b/src/combinatorics/combinations.js
@@ -1,15 +1,15 @@
 (function (exports) {
   'use strict';
 
-  var combinations = (function () {
-    var res = [];
+  let combinations = (function () {
+    let res = [];
 
     function combinations(arr, k, start, idx, current) {
       if (idx === k) {
         res.push(current.slice());
         return;
       }
-      for (var i = start; i < arr.length; i += 1) {
+      for (let i = start; i < arr.length; i += 1) {
         current[idx] = arr[i];
         combinations(arr, k, i + 1, idx + 1, current);
       }
@@ -42,7 +42,7 @@
     return function (arr, k) {
       res = [];
       combinations(arr, k, 0, 0, []);
-      var temp = res;
+      let temp = res;
       // Free the extra memory
       res = null;
       return temp;

--- a/src/combinatorics/permutations.js
+++ b/src/combinatorics/permutations.js
@@ -1,11 +1,11 @@
 (function (exports) {
   'use strict';
-  var permutations = (function () {
+  let permutations = (function () {
 
-    var res;
+    let res;
 
     function swap(arr, i, j) {
-      var temp = arr[i];
+      let temp = arr[i];
       arr[i] = arr[j];
       arr[j] = temp;
     }
@@ -14,7 +14,7 @@
       if (current >= arr.length) {
         return res.push(arr.slice());
       }
-      for (var i = current; i < arr.length; i += 1) {
+      for (let i = current; i < arr.length; i += 1) {
         swap(arr, i, current);
         permutations(arr, current + 1);
         swap(arr, i, current);
@@ -51,7 +51,7 @@
     return function (arr) {
       res = [];
       permutations(arr, 0);
-      var temp = res;
+      let temp = res;
       // Free the extra memory
       res = null;
       return temp;

--- a/src/combinatorics/variations-repetition.js
+++ b/src/combinatorics/variations-repetition.js
@@ -1,14 +1,14 @@
 (function (exports) {
   'use strict';
 
-  var variationsWithRepetition = (function () {
-    var res;
+  let variationsWithRepetition = (function () {
+    let res;
 
     function variations(arr, k, index, current) {
       if (k === index) {
         return res.push(current.slice());
       }
-      for (var i = 0; i < arr.length; i += 1) {
+      for (let i = 0; i < arr.length; i += 1) {
         current[index] = arr[i];
         variations(arr, k, index + 1, current);
       }
@@ -44,7 +44,7 @@
     return function (arr, k) {
       res = [];
       variations(arr, k, 0, []);
-      var temp = res;
+      let temp = res;
       res = undefined;
       return temp;
     };

--- a/src/compression/LZW/LZW.js
+++ b/src/compression/LZW/LZW.js
@@ -26,12 +26,12 @@
   };
 
   exports.LZW.compress = function (data) {
-    var i;
-    var dictionary = {};
-    var character;
-    var wc;
-    var w = '';
-    var result = [];
+    let i;
+    let dictionary = {};
+    let character;
+    let wc;
+    let w = '';
+    let result = [];
 
     for (i = 0; i < this.dictionarySize; i = i + 1) {
       dictionary[String.fromCharCode(i)] = i;
@@ -58,12 +58,12 @@
   };
 
   exports.LZW.decompress = function (compressedData) {
-    var i;
-    var dictionary = [];
-    var w;
-    var result;
-    var key;
-    var entry = '';
+    let i;
+    let dictionary = [];
+    let w;
+    let result;
+    let key;
+    let entry = '';
 
     for (i = 0; i < this.dictionarySize; i = i + 1) {
       dictionary[i] = String.fromCharCode(i);

--- a/src/compression/burrows-wheeler/burrows-wheeler.js
+++ b/src/compression/burrows-wheeler/burrows-wheeler.js
@@ -29,12 +29,12 @@
    */
   exports.burrowsWheeler.encode = function(str) {
     str = '$' + str;
-    var combinations = [];
+    let combinations = [];
     for (let i = 0; i < str.length; i += 1) {
       combinations.push(str.substring(i) + str.substring(0, i));
     }
-    var sorted = combinations.sort();
-    var result = [];
+    let sorted = combinations.sort();
+    let result = [];
     for (let i = 0; i < sorted.length; i += 1) {
       result.push(combinations[i][str.length - 1]);
     }
@@ -45,11 +45,11 @@
     const sortedCharSequence = encodedStr.split('').sort().join('');
     const leftSide = {};
     const rightSide = {};
-    var maxEachCharLeft = {};
-    var maxEachCharRight = {};
+    let maxEachCharLeft = {};
+    let maxEachCharRight = {};
 
     for (let i = 0; i < encodedStr.length; i += 1) {
-      var idLeft = sortedCharSequence[i];
+      let idLeft = sortedCharSequence[i];
       if (idLeft in maxEachCharLeft) {
         maxEachCharLeft[idLeft] = maxEachCharLeft[idLeft] + 1;
       } else {
@@ -57,7 +57,7 @@
       }
       idLeft += String(maxEachCharLeft[idLeft]);
 
-      var idRight = encodedStr[i];
+      let idRight = encodedStr[i];
       if (idRight in maxEachCharRight) {
         maxEachCharRight[idRight] = maxEachCharRight[idRight] + 1;
       } else {
@@ -68,10 +68,10 @@
       leftSide[idLeft] = {char: sortedCharSequence[i], right: idRight};
       rightSide[idRight] = {char: encodedStr[i], left: idRight};
     }
-    var result = '';
-    var firstChar = sortedCharSequence[0];
-    var searchChar = firstChar + '1';
-    var endChar = searchChar;
+    let result = '';
+    let firstChar = sortedCharSequence[0];
+    let searchChar = firstChar + '1';
+    let endChar = searchChar;
     while (rightSide[leftSide[searchChar].right].left !== endChar) {
       result     += leftSide[searchChar].char;
       searchChar = rightSide[leftSide[searchChar].right].left;

--- a/src/compression/runlength/runlength.js
+++ b/src/compression/runlength/runlength.js
@@ -7,16 +7,16 @@
 (function (exports) {
   'use strict';
 
-  var runLengthEncoding = (function () {
+  let runLengthEncoding = (function () {
 
     /**
      * Converts a given string to sequence of numbers
      * This takes O(n).
      */
     function convertToAscii(str) {
-      var result = [];
-      var currentChar = '';
-      var i = 0;
+      let result = [];
+      let currentChar = '';
+      let i = 0;
       for (; i < str.length; i += 1) {
         currentChar = str[i].charCodeAt(0).toString(2);
         currentChar = new Array(9 - currentChar.length).join('0') + currentChar;
@@ -30,10 +30,10 @@
      * Takes O(n^2).
      */
     function runLength(vector) {
-      var result = [];
-      var zeros = 0;
-      var zerosTemp = '';
-      var i = 0;
+      let result = [];
+      let zeros = 0;
+      let zerosTemp = '';
+      let i = 0;
       for (; i < vector.length; i += 1) {
         if (vector[i] === '0') {
           zeros += 1;
@@ -53,7 +53,7 @@
      * Takes O(n^2).
      */
     return function (str) {
-      var asciiString = convertToAscii(str);
+      let asciiString = convertToAscii(str);
       return runLength(asciiString);
     };
 

--- a/src/data-structures/avl-tree.js
+++ b/src/data-structures/avl-tree.js
@@ -60,7 +60,7 @@
    */
   exports.AVLTree.prototype._getHeightAtNode = function (node) {
     if (node._left !== null && node._right !== null){
-      var height = Math.max(node._left._height, node._right._height);
+      let height = Math.max(node._left._height, node._right._height);
       height += 1;
       return height;
     } else if (node._left !== null){
@@ -104,12 +104,12 @@
    */
   exports.AVLTree.prototype._getNodesToRestructureRemove = function (traveledNodes) {
     // z is last traveled node - imbalance found at z
-    var zIndex = traveledNodes.length;
+    let zIndex = traveledNodes.length;
     zIndex -= 1;
-    var z = traveledNodes[zIndex];
+    let z = traveledNodes[zIndex];
     // y should be child of z with larger height
     // (cannot be ancestor of removed node)
-    var y;
+    let y;
     if ((z._left !== null && z._right !== null) || (z._left !== null && z._right === null)){
       y = z._left;
     } else if (z._right !== null && z._left === null){
@@ -118,7 +118,7 @@
     // x should be tallest child of y.
     // If children same height, x should be child of y
     // that has same orientation as z to y.
-    var x;
+    let x;
     if (y._left !== null && y._right !== null){
       if (y._left._height > y._right._height){
         x = y._left;
@@ -146,26 +146,26 @@
    */
   exports.AVLTree.prototype._getNodesToRestructureInsert = function (traveledNodes) {
     // z is last traveled node - imbalance found at z
-    var zIndex = traveledNodes.length;
+    let zIndex = traveledNodes.length;
     zIndex -= 1;
-    var z = traveledNodes[zIndex];
+    let z = traveledNodes[zIndex];
     // y should be child of z with larger height
     // (must be ancestor of inserted node)
     // therefore, last traveled node is correct.
-    var yIndex = traveledNodes.length;
+    let yIndex = traveledNodes.length;
     yIndex -= 2;
-    var y = traveledNodes[yIndex];
+    let y = traveledNodes[yIndex];
     // x should be tallest child of y.
     // If children same height, x should be ancestor
     // of inserted node (in traveled path).
-    var x;
+    let x;
     if (y._left !== null && y._right !== null){
       if (y._left._height > y._right._height){
         x = y._left;
       } else if (y._left._height < y._right._height){
         x = y._right;
       } else if (y._left._height === y._right._height){
-        var xIndex = traveledNodes.length;
+        let xIndex = traveledNodes.length;
         xIndex -= 3;
         x = traveledNodes[xIndex];
       }
@@ -189,13 +189,13 @@
    * @param {Boolean} isRemove Represents if method was called after remove.
    */
   exports.AVLTree.prototype._maintainHeightBalanceProperty = function (node, isRemove) {
-    var current = node;
-    var traveledNodes = [];
+    let current = node;
+    let traveledNodes = [];
     while (current !== null){
       traveledNodes.push(current);
       current._height = this._getHeightAtNode(current);
       if (!this._isBalancedAtNode(current)){
-        var nodesToBeRestructured = (isRemove)
+        let nodesToBeRestructured = (isRemove)
           ? this._getNodesToRestructureRemove(traveledNodes)
           : this._getNodesToRestructureInsert(traveledNodes);
         this._restructure(nodesToBeRestructured);
@@ -214,9 +214,9 @@
    * array of nodes, in format, [x, y, z], to be restructured
    */
   exports.AVLTree.prototype._restructure = function (nodesToBeRestructured) {
-    var x = nodesToBeRestructured[0];
-    var y = nodesToBeRestructured[1];
-    var z = nodesToBeRestructured[2];
+    let x = nodesToBeRestructured[0];
+    let y = nodesToBeRestructured[1];
+    let z = nodesToBeRestructured[2];
     //Determine Rotation Pattern
     if (z._right === y && y._right === x){
       this._rightRight(x, y, z);
@@ -247,7 +247,7 @@
     */
     // pass z parent to y and move y's left to z's right
     if (z._parent !== null){
-      var orientation = (z._parent._left === z) ? '_left' : '_right';
+      let orientation = (z._parent._left === z) ? '_left' : '_right';
       z._parent[orientation] = y;
       y._parent = z._parent;
     } else {
@@ -286,7 +286,7 @@
     */
     //pass z parent to y and move y's right to z's left
     if (z._parent !== null){
-      var orientation = (z._parent._left === z) ? '_left' : '_right';
+      let orientation = (z._parent._left === z) ? '_left' : '_right';
       z._parent[orientation] = y;
       y._parent = z._parent;
     } else {
@@ -324,7 +324,7 @@
      */
     //pass z parent to x
     if (z._parent !== null){
-      var orientation = (z._parent._left === z) ? '_left' : '_right';
+      let orientation = (z._parent._left === z) ? '_left' : '_right';
       z._parent[orientation] = x;
       x._parent = z._parent;
     } else {
@@ -369,7 +369,7 @@
      */
     //pass z parent to x
     if (z._parent !== null){
-      var orientation = (z._parent._left === z) ? '_left' : '_right';
+      let orientation = (z._parent._left === z) ? '_left' : '_right';
       z._parent[orientation] = x;
       x._parent = z._parent;
     } else {
@@ -412,7 +412,7 @@
       this._maintainHeightBalanceProperty(this._root);
       return;
     }
-    var insertKey;
+    let insertKey;
     current = current || this._root;
     if (current.value > value) {
       insertKey = '_left';
@@ -591,13 +591,13 @@
    *    on whether the given node is removed.
    */
   exports.AVLTree.prototype.remove = function (value) {
-    var node = this.find(value);
+    let node = this.find(value);
     if (!node) {
       return false;
     }
     if (node._left && node._right) {
-      var min = this._findMin(node._right);
-      var temp = node.value;
+      let min = this._findMin(node._right);
+      let temp = node.value;
       node.value = min.value;
       min.value = temp;
       return this.remove(temp);
@@ -702,13 +702,13 @@
    * @returns {Number} The longest path in the AVL Tree.
    */
   exports.AVLTree.prototype.getDiameter = function () {
-    var getDiameter = function (root) {
+    const getDiameter = function (root) {
       if (!root) {
         return 0;
       }
-      var leftHeight = this._getHeight(root._left);
-      var rightHeight = this._getHeight(root._right);
-      var path = leftHeight + rightHeight + 1;
+      let leftHeight = this._getHeight(root._left);
+      let rightHeight = this._getHeight(root._right);
+      let path = leftHeight + rightHeight + 1;
       return Math.max(path, getDiameter(root._left), getDiameter(root._right));
     }.bind(this);
     return getDiameter(this._root);
@@ -743,10 +743,10 @@
   };
 
   exports.AVLTree.prototype._lowestCommonAncestor = function (firstNode, secondNode, current) {
-    var firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
-    var secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
-    var firstNodeInRight = this._existsInSubtree(firstNode, current._right);
-    var secondNodeInRight = this._existsInSubtree(secondNode, current._right);
+    let firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
+    let secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
+    let firstNodeInRight = this._existsInSubtree(firstNode, current._right);
+    let secondNodeInRight = this._existsInSubtree(secondNode, current._right);
     if ((firstNodeInLeft && secondNodeInRight) ||
         (firstNodeInRight && secondNodeInLeft)) {
       return current;

--- a/src/data-structures/binary-search-tree.js
+++ b/src/data-structures/binary-search-tree.js
@@ -71,7 +71,7 @@
       this._root = new exports.Node(value, null, null, null);
       return;
     }
-    var insertKey;
+    let insertKey;
     current = current || this._root;
     if (current.value > value) {
       insertKey = '_left';
@@ -253,8 +253,8 @@
       return false;
     }
     if (node._left && node._right) {
-      var min = this._findMin(node._right);
-      var temp = node.value;
+      let min = this._findMin(node._right);
+      let temp = node.value;
       node.value = min.value;
       min.value = temp;
       return this.remove(min);
@@ -363,13 +363,13 @@
    * @returns {Number} The longest path in the BST.
    */
   exports.BinaryTree.prototype.getDiameter = function () {
-    var getDiameter = function (root) {
+    const getDiameter = function (root) {
       if (!root) {
         return 0;
       }
-      var leftHeight = this._getHeight(root._left);
-      var rightHeight = this._getHeight(root._right);
-      var path = leftHeight + rightHeight + 1;
+      let leftHeight = this._getHeight(root._left);
+      let rightHeight = this._getHeight(root._right);
+      let path = leftHeight + rightHeight + 1;
       return Math.max(path, getDiameter(root._left), getDiameter(root._right));
     }.bind(this);
     return getDiameter(this._root);
@@ -426,10 +426,10 @@
    * @returns {Node} The lowest common ancestor of the two nodes or null.
    */
   exports.BinaryTree.prototype._lowestCommonAncestor = function (firstNode, secondNode, current) {
-    var firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
-    var secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
-    var firstNodeInRight = this._existsInSubtree(firstNode, current._right);
-    var secondNodeInRight = this._existsInSubtree(secondNode, current._right);
+    let firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
+    let secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
+    let firstNodeInRight = this._existsInSubtree(firstNode, current._right);
+    let secondNodeInRight = this._existsInSubtree(secondNode, current._right);
     if ((firstNodeInLeft && secondNodeInRight) ||
         (firstNodeInRight && secondNodeInLeft)) {
       return current;

--- a/src/data-structures/bloomfilter.js
+++ b/src/data-structures/bloomfilter.js
@@ -29,9 +29,9 @@
    */
   function hashFnv32a(str, asString, seed) {
     /*jshint bitwise:false */
-    var i;
-    var l;
-    var hval = seed === undefined ? 0x811c9dc5 : seed;
+    let i;
+    let l;
+    let hval = seed === undefined ? 0x811c9dc5 : seed;
 
     for (i = 0, l = str.length; i < l; i = i + 1) {
       hval ^= str.charCodeAt(i);
@@ -92,9 +92,9 @@
     }
 
     // Calculate the offset within the int
-    var intOffset = index % 32;
-    var arrayOffset = Math.floor(index / 32); // the offset for the array
-    var mask = 1 << intOffset;
+    let intOffset = index % 32;
+    let arrayOffset = Math.floor(index / 32); // the offset for the array
+    let mask = 1 << intOffset;
     return (mask & this.intArray[arrayOffset]) !== 0;
   };
 
@@ -110,9 +110,9 @@
     }
 
     // Calculate the offset within the int
-    var intOffset = index % 32;
-    var arrayOffset = Math.floor(index / 32); // the offset for the array
-    var mask = 1 << intOffset;
+    let intOffset = index % 32;
+    let arrayOffset = Math.floor(index / 32); // the offset for the array
+    let mask = 1 << intOffset;
     if ((mask & this.intArray[arrayOffset]) !== 0) {
       return 1;
     } else {
@@ -132,9 +132,9 @@
       throw new Error('Index out of bound')
     }
 
-    var intOffset = index % 32; //calculate the offset within the int
-    var arrayOffset = Math.floor(index / 32); // the offset for the array
-    var mask = 1 << intOffset;
+    let intOffset = index % 32; //calculate the offset within the int
+    let arrayOffset = Math.floor(index / 32); // the offset for the array
+    let mask = 1 << intOffset;
 
     // Check trutyness
     if (value) {
@@ -163,7 +163,7 @@
     this.errorRate = errorRate;
 
     // Calculate the optimal size of the bitmap
-    var numBit = Math.ceil(
+    let numBit = Math.ceil(
       (capacity * Math.log(1.0 / errorRate)) / Math.pow(Math.log(2), 2)
     );
 
@@ -189,12 +189,12 @@
    */
   exports.Bloomfilter.prototype.get = function(value) {
     value = String(value); // make it string
-    var hashes = this.hashFunctions.map(function(hashFct) {
+    let hashes = this.hashFunctions.map(function(hashFct) {
       return hashFct(value);
     });
 
     // if one of the bits is not set
-    for (var i = 0; i < hashes.length; i = i + 1) {
+    for (let i = 0; i < hashes.length; i = i + 1) {
       if (this.bitmap.exists(hashes[i]) === false) {
         return false;
       }
@@ -209,12 +209,12 @@
    */
   exports.Bloomfilter.prototype.set = function(value) {
     value = String(value); // make it string
-    var hashes = this.hashFunctions.map(function(hashFct) {
+    let hashes = this.hashFunctions.map(function(hashFct) {
       return hashFct(value);
     });
 
     // Set all the corresponding bits
-    for (var i = 0; i < hashes.length; i = i + 1) {
+    for (let i = 0; i < hashes.length; i = i + 1) {
       this.bitmap.set(hashes[i], true);
     }
   };

--- a/src/data-structures/hash-table.js
+++ b/src/data-structures/hash-table.js
@@ -63,9 +63,9 @@
    * @param {Number|String} val Key to be hashed.
    */
   exports.Hashtable.prototype.hashCode = function (val) {
-    var i;
-    var hashCode = 0;
-    var character;
+    let i;
+    let hashCode = 0;
+    let character;
 
     // If value to be hashed is already an integer, return it.
     if (val.length === 0 || val.length === undefined) {
@@ -106,7 +106,7 @@
     // Adjust hash to fit within buckets.
     hashCode = hashCode % this.maxBucketCount;
 
-    var newNode = new exports.Node(key, data);
+    let newNode = new exports.Node(key, data);
 
     // No element exists at hash/index for given key -> put in table.
     if (this.buckets[hashCode] === undefined) {
@@ -124,7 +124,7 @@
       Item exists at hash/index for key, but different key.
       Handle collision.
     */
-    var first = this.buckets[hashCode];
+    let first = this.buckets[hashCode];
     while (first.next !== undefined) {
       first = first.next;
     }
@@ -161,7 +161,7 @@
     ) {
       return this.buckets[hashCode].data;
     } else {
-      var first = this.buckets[hashCode];
+      let first = this.buckets[hashCode];
       while (
         first !== undefined &&
         first.next !== undefined &&
@@ -204,7 +204,7 @@
     } else if (this.buckets[hashCode].next === undefined) {
       this.buckets[hashCode] = undefined;
     } else {
-      var first = this.buckets[hashCode];
+      let first = this.buckets[hashCode];
 
       while (
         first !== undefined &&
@@ -214,7 +214,7 @@
         first = first.next;
       }
 
-      var removedValue = first.data;
+      let removedValue = first.data;
 
       // Removing (B)
       // (B) : only item in bucket

--- a/src/data-structures/heap.js
+++ b/src/data-structures/heap.js
@@ -71,10 +71,10 @@
    * @param {Number} index The parent.
    */
   exports.Heap.prototype._heapify = function (index) {
-    var extr = index;
-    var left = 2 * index + 1;
-    var right = 2 * index + 2;
-    var temp;
+    let extr = index;
+    let left = 2 * index + 1;
+    let right = 2 * index + 2;
+    let temp;
 
     if (left < this._heap.length &&
         this._cmp(this._heap[left], this._heap[index]) > 0) {
@@ -106,9 +106,9 @@
    */
   exports.Heap.prototype.changeKey = function (index, value) {
     this._heap[index] = value;
-    var elem = this._heap[index];
-    var parent = Math.floor(index / 2);
-    var temp;
+    let elem = this._heap[index];
+    let parent = Math.floor(index / 2);
+    let temp;
     if (elem !== undefined) {
       while (parent >= 0 && this._cmp(elem, this._heap[parent]) > 0) {
         temp = this._heap[parent];
@@ -131,7 +131,7 @@
    * @param {Number|Object} node Node which should be updated.
    */
   exports.Heap.prototype.update = function (node) {
-    var idx = this._heap.indexOf(node);
+    let idx = this._heap.indexOf(node);
     if (idx >= 0) {
       this.changeKey(idx, node);
     }
@@ -173,7 +173,7 @@
     if (!this._heap.length) {
       throw 'The heap is already empty!';
     }
-    var extr = this._heap.shift();
+    let extr = this._heap.shift();
     this._heapify(0);
     return extr;
   };

--- a/src/data-structures/interval-tree.js
+++ b/src/data-structures/interval-tree.js
@@ -75,7 +75,7 @@
   };
 
   function addNode(node, side, interval) {
-    var child = new exports.Node(interval[0], interval[1]);
+    let child = new exports.Node(interval[0], interval[1]);
     child.max = interval[1];
     child.parentNode = node;
     node[side] = child;
@@ -127,8 +127,8 @@
     if (node.interval[0] <= point && node.interval[1] >= point) {
       return true;
     }
-    var result = false;
-    var temp;
+    let result = false;
+    let temp;
     ['left', 'right'].forEach(function (key) {
       temp = node[key];
       if (temp) {
@@ -165,8 +165,8 @@
     if (intersects(node.interval, interval)) {
       return true;
     }
-    var result = false;
-    var temp;
+    let result = false;
+    let temp;
     ['left', 'right'].forEach(function (side) {
       temp = node[side];
       if (temp && temp.max >= interval[0]) {
@@ -216,10 +216,10 @@
    * @return {Node} Node with the largest endpoint.
    */
   exports.IntervalTree.prototype.findMax = function (node) {
-    var stack = [node];
-    var current;
-    var max = -Infinity;
-    var maxNode;
+    let stack = [node];
+    let current;
+    let max = -Infinity;
+    let maxNode;
     while (stack.length) {
       current = stack.pop();
       if (current.left) {
@@ -245,21 +245,21 @@
         node.interval[1] === interval[1]) {
       // When left and right children exists
       if (node.left && node.right) {
-        var replacement = node.left;
+        let replacement = node.left;
         while (replacement.left) {
           replacement = replacement.left;
         }
-        var temp = replacement.interval;
+        let temp = replacement.interval;
         replacement.interval = node.interval;
         node.interval = temp;
         this._removeHelper(replacement.interval, node);
       } else {
         // When only left or right child exists
-        var side = 'left';
+        let side = 'left';
         if (node.right) {
           side = 'right';
         }
-        var parentNode = node.parentNode;
+        let parentNode = node.parentNode;
         if (parentNode) {
           if (parentNode.left === node) {
             parentNode.left = node[side];
@@ -278,10 +278,10 @@
         }
       }
       // Adjust the max value
-      var p = node.parentNode;
+      let p = node.parentNode;
       if (p) {
-        var maxNode = this.findMax(p);
-        var max = maxNode.interval[1];
+        let maxNode = this.findMax(p);
+        let max = maxNode.interval[1];
         while (maxNode) {
           if (maxNode.max === node.interval[1]) {
             maxNode.max = max;

--- a/src/data-structures/linked-list.js
+++ b/src/data-structures/linked-list.js
@@ -81,11 +81,11 @@
    * @param {Object} data Data which should be added.
    */
   exports.LinkedList.prototype.push = function (data) {
-    var node = new exports.Node(data);
+    let node = new exports.Node(data);
     if (this.first === null) {
       this.first = this.last = node;
     } else {
-      var temp = this.last;
+      let temp = this.last;
       this.last = node;
       node.prev = temp;
       temp.next = node;
@@ -100,11 +100,11 @@
    * @param {Object} data Data which should be added.
    */
   exports.LinkedList.prototype.unshift = function (data) {
-    var node = new exports.Node(data);
+    let node = new exports.Node(data);
     if (this.first === null) {
       this.first = this.last = node;
     } else {
-      var temp = this.first;
+      let temp = this.first;
       this.first = node;
       node.next = temp;
       temp.prev = node;
@@ -119,7 +119,7 @@
    * @param {Function} cb Callback which should be executed on each node.
    */
   exports.LinkedList.prototype.inorder = function (cb) {
-    var temp = this.first;
+    let temp = this.first;
     while (temp) {
       cb(temp);
       temp = temp.next;
@@ -138,11 +138,11 @@
     if (this.first === null) {
       return false;
     }
-    var temp = this.first;
-    var next;
-    var prev;
+    let temp = this.first;
+    let next;
+    let prev;
     while (temp) {
-      var dataFound = equals ? equals(temp.data, data) : temp.data === data;
+      let dataFound = equals ? equals(temp.data, data) : temp.data === data;
       if (dataFound) {
         next = temp.next;
         prev = temp.prev;
@@ -173,8 +173,8 @@
    * @return {Boolean} Returns true if linked list contains cycle.
    */
   exports.LinkedList.prototype.hasCycle = function () {
-    var fast = this.first;
-    var slow = this.first;
+    let fast = this.first;
+    let slow = this.first;
     while (true) {
       if (fast === null) {
         return false;
@@ -202,7 +202,7 @@
     if (this.last === null) {
       return null;
     }
-    var temp = this.last;
+    let temp = this.last;
     this.last = this.last.prev;
     return temp;
   };
@@ -218,7 +218,7 @@
     if (this.first === null) {
       return null;
     }
-    var temp = this.first;
+    let temp = this.first;
     this.first = this.first.next;
     return temp;
   };
@@ -246,7 +246,7 @@
     inverse(this.first, this.first.next);
     this.first.prev = this.first.next;
     this.first.next = null;
-    var temp = this.first;
+    let temp = this.first;
     this.first = this.last;
     this.last = temp;
   };
@@ -261,8 +261,8 @@
     if (!this.first || !this.first.next) {
       return;
     }
-    var current = this.first
-    var next
+    let current = this.first
+    let next
 
     do {
       next = current.next
@@ -271,7 +271,7 @@
       current = next
     } while (next)
 
-    var tmp = this.first
+    let tmp = this.first
     this.first = this.last
     this.last = tmp
   };

--- a/src/data-structures/red-black-tree.js
+++ b/src/data-structures/red-black-tree.js
@@ -35,7 +35,7 @@
   /**
    * Enum for the different colors
    */
-  var Colors = {
+  let Colors = {
     RED: 0,
     BLACK: 1
   };
@@ -92,7 +92,7 @@
   'key value left right color'
   .split(' ')
   .forEach(function (key) {
-    var valueName = key.substr(0, 1).toUpperCase() + key.substr(1, key.length);
+    let valueName = key.substr(0, 1).toUpperCase() + key.substr(1, key.length);
     Node.prototype['get' + valueName] = function () {
       return this['_' + key];
     };
@@ -154,7 +154,7 @@
    * @param {Node} node Node.
    */
   exports.RBTree.prototype._put = function (key, value, node) {
-    var newRoot = node;
+    let newRoot = node;
     if (node === null) {
       return new Node(key, value, null, null, Colors.RED);
     }
@@ -200,9 +200,9 @@
    * @return {Node} Right node.
    */
   exports.RBTree.prototype._rotateLeft = function (node) {
-    var x = node.getRight();
+    let x = node.getRight();
     if (x !== null) {
-      var temp = x.getLeft();
+      let temp = x.getLeft();
       node.setRight(temp);
       x.setLeft(node);
       x.setColor(node.getColor());
@@ -221,9 +221,9 @@
    * @return {Node} Left node.
    */
   exports.RBTree.prototype._rotateRight = function (node) {
-    var x = node.getLeft();
+    let x = node.getLeft();
     if (x !== null) {
-      var temp = x.getRight();
+      let temp = x.getRight();
       node.setLeft(temp);
       x.setRight(node);
       x.setColor(node.getColor());
@@ -276,15 +276,15 @@
   *
   */
   exports.RBTree.prototype.levelOrderTraversal = function () {
-    var queue = [];
-    var levelOrderString = '';
+    let queue = [];
+    let levelOrderString = '';
     if (this._root){
       queue.push(this._root);
     } else {
       levelOrderString = ' Tree is empty';
     }
     while (queue.length !== 0){
-      var tempNode = queue.shift();
+      let tempNode = queue.shift();
       levelOrderString += ' ' + tempNode.getKey();
       if (tempNode.getLeft() !== null){
         queue.push(tempNode.getLeft());

--- a/src/data-structures/segment-tree.js
+++ b/src/data-structures/segment-tree.js
@@ -46,23 +46,23 @@
    *  intermediate nodes.
    */
   SegmentTree.indexArray = function (array, placeholder, aggregate) {
-    var segmentize = function (original, data, lo, hi, idx) {
+    const segmentize = function (original, data, lo, hi, idx) {
       if (lo === hi) {
         data[idx] = original[lo];
       } else {
-        var mid = Math.floor((lo + hi) / 2);
-        var left = 2 * idx + 1;
-        var right = 2 * idx + 2;
+        let mid = Math.floor((lo + hi) / 2);
+        let left = 2 * idx + 1;
+        let right = 2 * idx + 2;
         segmentize(original, data, lo, mid, left);
         segmentize(original, data, mid + 1, hi, right);
         data[idx] = aggregate(data[left], data[right]);
       }
     };
-    var result = [];
+    let result = [];
     if (array && array.length) {
       segmentize(array, result, 0, array.length - 1, 0);
     }
-    var tree = new SegmentTree(placeholder, aggregate);
+    let tree = new SegmentTree(placeholder, aggregate);
     tree._data = result;
     tree._original = array;
     return tree;
@@ -78,7 +78,7 @@
     if (start > end) {
       throw new Error('The start index should be smaller by the end index');
     }
-    var findEl = function (originalArrayStart, originalArrayEnd, current) {
+    const findEl = function (originalArrayStart, originalArrayEnd, current) {
       if (start > originalArrayEnd) {
         return this._invalidValue;
       }
@@ -89,7 +89,7 @@
           originalArrayStart === originalArrayEnd) {
         return this._data[current];
       }
-      var originalArrayMid =
+      let originalArrayMid =
         Math.floor((originalArrayStart + originalArrayEnd) / 2);
       return this._aggregate(
         findEl(originalArrayStart, originalArrayMid, 2 * current + 1),

--- a/src/data-structures/size-balanced-tree.js
+++ b/src/data-structures/size-balanced-tree.js
@@ -89,7 +89,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
     if (node === Nil) {
       return node;
     }
-    var savedNode = node;
+    let savedNode = node;
     if (leftChild) {
       if (node.left.left.size > node.right.size) {
         node = RightRotate(node, node.left);
@@ -117,7 +117,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
 
   function maintainSizeBalancedTree(node) {
     while (node.parent !== Nil) {
-      var childNode = node;
+      let childNode = node;
       node = node.parent;
       if (node.left === childNode) {
         node = maintain(node, true);
@@ -147,7 +147,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
    * @public
    * @constructor
    */
-  var SBTree = function () {};
+  let SBTree = function () {};
 
   SBTree.prototype = {
     _root: Nil,
@@ -160,11 +160,11 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
     },
 
     binarySearch: function (cmp, value) {
-      var left = -1;
-      var right = this.size;
+      let left = -1;
+      let right = this.size;
       while (left + 1 < right) {
-        var middle = (left + right) >> 1; // jshint ignore:line
-        var result = cmp(this.get(middle).value, value);
+        let middle = (left + right) >> 1; // jshint ignore:line
+        let result = cmp(this.get(middle).value, value);
         if (result <= 0) {
           left = middle;
         } else {
@@ -183,9 +183,9 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
   };
 
   SBTree.prototype.getIndex = function (node) {
-    var index = node.left.size;
+    let index = node.left.size;
     while (node !== this._root) {
-      var parent = node.parent;
+      let parent = node.parent;
       if (parent.right === node) {
         index += parent.left.size + 1;
       }
@@ -195,7 +195,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
   };
 
   SBTree.prototype.shiftDown = function (node) {
-    var direction = 0;
+    let direction = 0;
     while (true) {
       if (node.left !== Nil && node.right !== Nil) {
         switch (direction) {
@@ -218,7 +218,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
   };
 
   SBTree.prototype.insertLeafNode = function (node) {
-    var parent = node.parent;
+    let parent = node.parent;
     while (parent !== Nil) {
       parent.size = parent.size + 1;
       parent = parent.parent;
@@ -226,7 +226,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
   };
 
   SBTree.prototype.removeLeafNode = function (node) {
-    var parent = node.parent;
+    let parent = node.parent;
     while (parent !== Nil) {
       parent.size = parent.size - 1;
       parent = parent.parent;
@@ -234,8 +234,8 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
   };
 
   SBTree.prototype.insert = function (pos, value) {
-    var node = Nil;
-    var newNode = new Node(value, Nil, Nil, Nil, 1);
+    let node = Nil;
+    let newNode = new Node(value, Nil, Nil, Nil, 1);
     if (pos === this.size) {
       if (pos > 0) {
         node = findNodeAtPos(this._root, pos - 1);
@@ -268,7 +268,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
 
   SBTree.prototype.removeNode = function (node) {
     this.shiftDown(node);
-    var maintainNode = node.parent;
+    let maintainNode = node.parent;
     if (maintainNode.left === node) {
       maintainNode.left = Nil;
     } else if (maintainNode.right === node) {
@@ -283,7 +283,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
     if (pos >= this._root.size) {
       return Nil; // There is no element to remove
     }
-    var node = findNodeAtPos(this._root, pos);
+    let node = findNodeAtPos(this._root, pos);
     return this.removeNode(node);
   };
 
@@ -304,7 +304,7 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
    * @param {Node} right Right node.
    * @param {Number} size Node's, means the Node count of this  .
    */
-  var NodeConstructor = function (value, parent, left, right, size) {
+  let NodeConstructor = function (value, parent, left, right, size) {
     this.value = value;
     this.parent = parent;
     this.left = left;
@@ -312,8 +312,8 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
     this.size = size;
   };
 
-  var createNil = function (Node, value) {
-    var Nil = new Node(value, null, null, null, 0);
+  let createNil = function (Node, value) {
+    let Nil = new Node(value, null, null, null, 0);
     Nil.parent = Nil;
     Nil.left = Nil;
     Nil.right = Nil;
@@ -326,14 +326,14 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
    * @private
    * @method
    */
-  var updateSize = function () {
+  let updateSize = function () {
     this.size = this.left.size + this.right.size + 1;
   };
 
   // node, childNode must not be Nil,
   // if the childNode turn out to be the root, the parent should be Nil
-  var updateChild = function (node, childNode) {
-    var parent = node.parent;
+  let updateChild = function (node, childNode) {
+    let parent = node.parent;
     node.parent = childNode;
     childNode.parent = parent;
 
@@ -348,13 +348,13 @@ function CreateSBTreeClass (Node, Nil, updateChild) {
     } // otherwise parent is Nil
   };
 
-  var Node = function () {
+  let Node = function () {
     NodeConstructor.apply(this, arguments);
   };
 
   Node.prototype.updateSize = updateSize;
 
-  var Nil = createNil(Node, null);
+  let Nil = createNil(Node, null);
 
   exports.NodeConstructor = NodeConstructor;
   exports.createNil = createNil;

--- a/src/data-structures/splay-tree.js
+++ b/src/data-structures/splay-tree.js
@@ -62,11 +62,11 @@
    */
   exports.SplayTree.prototype._splay = function (node) {
     while (this._root !== node) {
-      var hasParent = node._parent !== null;
-      var hasGrandparent = (hasParent && node._parent._parent !== null);
+      let hasParent = node._parent !== null;
+      let hasGrandparent = (hasParent && node._parent._parent !== null);
       if (hasParent && hasGrandparent) {
-        var isLeftChild = node._parent._left === node;
-        var isParentLeftChild = node._parent._parent._left === node._parent;
+        let isLeftChild = node._parent._left === node;
+        let isParentLeftChild = node._parent._parent._left === node._parent;
         if (
           (isLeftChild && isParentLeftChild) ||
           (!isLeftChild && !isParentLeftChild)
@@ -92,14 +92,14 @@
    */
   exports.SplayTree.prototype._zigZig = function (node) {
 
-    var parent = node._parent;
-    var grandParent = node._parent._parent;
-    var greatGrandParent = grandParent._parent !== undefined ?
+    let parent = node._parent;
+    let grandParent = node._parent._parent;
+    let greatGrandParent = grandParent._parent !== undefined ?
       grandParent._parent : null;
 
-    var orientation = (parent._right === node) ? '_right' : '_left';
-    var oppositeOrientation = (orientation === '_left') ? '_right' : '_left';
-    var grandParentOrientation = (greatGrandParent !== null &&
+    let orientation = (parent._right === node) ? '_right' : '_left';
+    let oppositeOrientation = (orientation === '_left') ? '_right' : '_left';
+    let grandParentOrientation = (greatGrandParent !== null &&
       greatGrandParent._left === grandParent) ? '_left' : '_right';
 
     // Fix grandparent & great if it exists/not root
@@ -142,14 +142,14 @@
    */
   exports.SplayTree.prototype._zigZag = function (node) {
 
-    var parent = node._parent;
-    var grandParent = parent._parent;
-    var greatGrandParent = grandParent._parent !== undefined ?
+    let parent = node._parent;
+    let grandParent = parent._parent;
+    let greatGrandParent = grandParent._parent !== undefined ?
       grandParent._parent : null;
 
-    var orientation = (parent._left === node) ? '_left' : '_right';
-    var oppositeOrientation = (orientation === '_right') ? '_left' : '_right';
-    var grandParentOrientation = (greatGrandParent !== null &&
+    let orientation = (parent._left === node) ? '_left' : '_right';
+    let oppositeOrientation = (orientation === '_right') ? '_left' : '_right';
+    let grandParentOrientation = (greatGrandParent !== null &&
       greatGrandParent._left === grandParent) ? '_left' : '_right';
 
     // Fix GrandParent
@@ -192,9 +192,9 @@
    */
   exports.SplayTree.prototype._zig = function (node) {
 
-    var parent = node._parent;
-    var orientation = (parent._right === node) ? '_right' : '_left';
-    var oppositeOrientation = (orientation === '_right') ? '_left' : '_right';
+    let parent = node._parent;
+    let orientation = (parent._right === node) ? '_right' : '_left';
+    let oppositeOrientation = (orientation === '_right') ? '_left' : '_right';
 
     if (this._root === parent) {
       this._root = node;
@@ -227,7 +227,7 @@
       this._root = new exports.Node(value, null, null, null);
       return;
     }
-    var insertKey;
+    let insertKey;
     current = current || this._root;
     if (current.value > value) {
       insertKey = '_left';
@@ -341,7 +341,7 @@
    * @param {Number|String} value of the node which should be found.
    */
   exports.SplayTree.prototype.search = function (value) {
-    var node = this._search(value, this._root);
+    let node = this._search(value, this._root);
     return this._splay(node);
   };
 
@@ -418,13 +418,13 @@
    *    on whether the given node is removed.
    */
   exports.SplayTree.prototype.remove = function (value) {
-    var node = this._splaylessSearch(value);
+    let node = this._splaylessSearch(value);
     if (!node) {
       return false;
     }
     if (node._left && node._right) {
-      var min = this._findMin(node._right);
-      var temp = node.value;
+      let min = this._findMin(node._right);
+      let temp = node.value;
 
       node.value = min.value;
       min.value = temp;
@@ -494,13 +494,13 @@
    * @returns {Number} The longest path in the tree.
    */
   exports.SplayTree.prototype.getDiameter = function () {
-    var getDiameter = function (root) {
+    const getDiameter = function (root) {
       if (!root) {
         return 0;
       }
-      var leftHeight = this._getHeight(root._left);
-      var rightHeight = this._getHeight(root._right);
-      var path = leftHeight + rightHeight + 1;
+      let leftHeight = this._getHeight(root._left);
+      let rightHeight = this._getHeight(root._right);
+      let path = leftHeight + rightHeight + 1;
       return Math.max(path, getDiameter(root._left), getDiameter(root._right));
     }.bind(this);
     return getDiameter(this._root);
@@ -555,10 +555,10 @@
    */
   exports.SplayTree.prototype._lowestCommonAncestor =
     function (firstNode, secondNode, current) {
-      var firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
-      var secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
-      var firstNodeInRight = this._existsInSubtree(firstNode, current._right);
-      var secondNodeInRight = this._existsInSubtree(secondNode, current._right);
+      let firstNodeInLeft = this._existsInSubtree(firstNode, current._left);
+      let secondNodeInLeft = this._existsInSubtree(secondNode, current._left);
+      let firstNodeInRight = this._existsInSubtree(firstNode, current._right);
+      let secondNodeInRight = this._existsInSubtree(secondNode, current._right);
       if ((firstNodeInLeft && secondNodeInRight) ||
         (firstNodeInRight && secondNodeInLeft)) {
         return current;

--- a/src/data-structures/suffix-tree.js
+++ b/src/data-structures/suffix-tree.js
@@ -13,8 +13,8 @@
   SuffixTree.prototype.addNode = (function () {
 
     function maxPrefix(a, b) {
-      var res = [];
-      for (var i = 0; i < Math.min(a.length, b.length); i += 1) {
+      let res = [];
+      for (let i = 0; i < Math.min(a.length, b.length); i += 1) {
         if (a[i] === b[i]) {
           res.push(a[i]);
         } else {
@@ -39,11 +39,11 @@
         current.nodes[suffix[0]]);
       }
       // Find the maximum prefix and split the current node if prefix exists
-      var prefix = maxPrefix(current.value, suffix);
+      let prefix = maxPrefix(current.value, suffix);
       if (prefix.length) {
-        var temp = current.value;
-        var suffixSuffix = suffix.substr(prefix.length, suffix.length);
-        var currentSuffix = temp.substr(prefix.length, temp.length);
+        let temp = current.value;
+        let suffixSuffix = suffix.substr(prefix.length, suffix.length);
+        let currentSuffix = temp.substr(prefix.length, temp.length);
         current.value = prefix;
         addNode(currentSuffix, current);
         addNode(suffixSuffix, current);
@@ -61,7 +61,7 @@
   // O(n^2) or even O(n^3) because of maxPrefix
   SuffixTree.prototype.build = function (string) {
     this.root.value = string;
-    for (var i = 1; i < string.length; i += 1) {
+    for (let i = 1; i < string.length; i += 1) {
       this.addNode(string.substr(i, string.length));
     }
   };

--- a/src/graphics/bresenham-line-drawing.js
+++ b/src/graphics/bresenham-line-drawing.js
@@ -20,13 +20,13 @@
    * @param  {function} draw Optional custom drawing function.
    */
   function drawLine(x1, y1, x2, y2, draw) {
-    var drawPointStrategy = draw || drawPoint;
-    var dx = Math.abs(x2 - x1);
-    var dy = Math.abs(y2 - y1);
-    var cx = (x1 < x2) ? 1 : -1;
-    var cy = (y1 < y2) ? 1 : -1;
-    var error = dx - dy;
-    var doubledError;
+    let drawPointStrategy = draw || drawPoint;
+    let dx = Math.abs(x2 - x1);
+    let dy = Math.abs(y2 - y1);
+    let cx = (x1 < x2) ? 1 : -1;
+    let cy = (y1 < y2) ? 1 : -1;
+    let error = dx - dy;
+    let doubledError;
 
     while (x1 !== x2 || y1 !== y2) {
       drawPointStrategy(x1, y1);

--- a/src/graphs/others/tarjan-connected-components.js
+++ b/src/graphs/others/tarjan-connected-components.js
@@ -31,7 +31,7 @@
     const onStack = {};
     const result = [];
     const stack = [];
-    var index = 1;
+    let index = 1;
 
     const connectedComponent = function (node) {
       stack.push(node);
@@ -50,7 +50,7 @@
       // This is a "root" node
       const cc = [];
       if (indexes[node] === lowIndexes[node]) {
-        var current;
+        let current;
         do {
           current = stack.pop();
           onStack[current] = false;

--- a/src/graphs/others/topological-sort.js
+++ b/src/graphs/others/topological-sort.js
@@ -1,13 +1,13 @@
 (function (exports) {
   'use strict';
 
-  var topologicalSort = (function () {
+  let topologicalSort = (function () {
 
     function topologicalSortHelper(node, visited, temp, graph, result) {
       temp[node] = true;
-      var neighbors = graph[node];
-      for (var i = 0; i < neighbors.length; i += 1) {
-        var n = neighbors[i];
+      let neighbors = graph[node];
+      for (let i = 0; i < neighbors.length; i += 1) {
+        let n = neighbors[i];
         if (temp[n]) {
           throw new Error('The graph is not a DAG');
         }
@@ -44,10 +44,10 @@
      * var vertices = topsort(graph); // ['v3', 'v4', 'v1', 'v5', 'v2']
      */
     return function (graph) {
-      var result = [];
-      var visited = [];
-      var temp = [];
-      for (var node in graph) {
+      let result = [];
+      let visited = [];
+      let temp = [];
+      for (let node in graph) {
         if (!visited[node] && !temp[node]) {
           topologicalSortHelper(node, visited, temp, graph, result);
         }

--- a/src/graphs/searching/bfs.js
+++ b/src/graphs/searching/bfs.js
@@ -1,10 +1,10 @@
 (function (exports) {
   'use strict';
 
-  var bfs = (function () {
+  let bfs = (function () {
 
     function buildPath(parents, targetNode) {
-      var result = [targetNode];
+      let result = [targetNode];
       while (parents[targetNode] !== null) {
         targetNode = parents[targetNode];
         result.push(targetNode);
@@ -35,10 +35,10 @@
      * var shortestPath = bfs(graph, 1, 5); // [1, 2, 3, 5]
      */
     return function (graph, startNode, targetNode) {
-      var parents = [];
-      var queue = [];
-      var visited = [];
-      var current;
+      let parents = [];
+      let queue = [];
+      let visited = [];
+      let current;
       queue.push(startNode);
       parents[startNode] = null;
       visited[startNode] = true;
@@ -47,7 +47,7 @@
         if (current === targetNode) {
           return buildPath(parents, targetNode);
         }
-        for (var i = 0; i < graph.length; i += 1) {
+        for (let i = 0; i < graph.length; i += 1) {
           if (i !== current && graph[current][i] && !visited[i]) {
             parents[i] = current;
             visited[i] = true;

--- a/src/graphs/searching/dfs.js
+++ b/src/graphs/searching/dfs.js
@@ -1,12 +1,12 @@
 (function (exports) {
   'use strict';
 
-  var dfs = (function () {
+  let dfs = (function () {
 
     function hasPath(graph, current, goal) {
-      var stack = [];
-      var visited = [];
-      var node;
+      let stack = [];
+      let visited = [];
+      let node;
       stack.push(current);
       visited[current] = true;
       while (stack.length) {
@@ -14,7 +14,7 @@
         if (node === goal) {
           return true;
         }
-        for (var i = 0; i < graph[node].length; i += 1) {
+        for (let i = 0; i < graph[node].length; i += 1) {
           if (graph[node][i] && !visited[i]) {
             stack.push(i);
             visited[i] = true;

--- a/src/graphs/shortest-path/bellman-ford.js
+++ b/src/graphs/shortest-path/bellman-ford.js
@@ -57,17 +57,18 @@
    *   has a negative cycle.
    */
   exports.bellmanFord = function (vertexes, edges, source) {
-    var distances = {};
-    var parents = {};
-    var c;
+    let distances = {};
+    let parents = {};
+    let c;
+    let i;
     if (source) {
-      for (var i = 0; i < vertexes.length; i += 1) {
+      for (i = 0; i < vertexes.length; i += 1) {
         distances[vertexes[i].id] = Infinity;
         parents[vertexes[i].id] = null;
       }
       distances[source.id] = 0;
       for (i = 0; i < vertexes.length - 1; i += 1) {
-        for (var j = 0; j < edges.length; j += 1) {
+        for (let j = 0; j < edges.length; j += 1) {
           c = edges[j];
           if (distances[c.from.id] + c.distance < distances[c.to.id]) {
             distances[c.to.id] = distances[c.from.id] + c.distance;

--- a/src/graphs/shortest-path/dijkstra.js
+++ b/src/graphs/shortest-path/dijkstra.js
@@ -1,13 +1,13 @@
 (function (exports) {
   'use strict';
 
-  var dijkstra = (function () {
+  let dijkstra = (function () {
 
-    var Heap = require('../../data-structures/heap.js').Heap;
-    var current;
-    var visited;
-    var distance;
-    var unvisited;
+    let Heap = require('../../data-structures/heap.js').Heap;
+    let current;
+    let visited;
+    let distance;
+    let unvisited;
 
     /**
      * Creates a new node instance.
@@ -42,12 +42,12 @@
      * @param {Array} graph A distance matrix of the graph.
      */
     function init(src, graph) {
-      var currentTemp;
+      let currentTemp;
       current = {};
       visited = [];
       distance = [];
       unvisited = new Heap(compareNodesDistance);
-      for (var i = 0; i < graph.length; i += 1) {
+      for (let i = 0; i < graph.length; i += 1) {
         currentTemp = new Node();
         if (src === i) {
           currentTemp.distance = 0;
@@ -92,10 +92,10 @@
      * var shortestDist = dijkstra(0, 2, distMatrix); // 9
      */
     return function (src, dest, graph) {
-      var tempDistance = 0;
+      let tempDistance = 0;
       init(src, graph);
       while (current.node !== dest && isFinite(current.distance)) {
-        for (var i = 0; i < graph.length; i += 1) {
+        for (let i = 0; i < graph.length; i += 1) {
           if (current.node !== i && //if it's not the current node
             !visited[i] && //and if we haven't visited this node
             //and this node is sibling of the current...

--- a/src/graphs/shortest-path/floyd-warshall.js
+++ b/src/graphs/shortest-path/floyd-warshall.js
@@ -1,12 +1,12 @@
 (function (exports) {
   'use strict';
 
-  var floydWarshall = (function () {
+  let floydWarshall = (function () {
 
     /**
      * Matrix used for the algorithm.
      */
-    var dist;
+    let dist;
 
     /**
      * Initialize the distance matrix.
@@ -16,11 +16,11 @@
      * @return {Array} Distance matrix used for the algorithm.
      */
     function init(graph) {
-      var dist = [];
-      var size = graph.length;
-      for (var i = 0; i < size; i += 1) {
+      let dist = [];
+      let size = graph.length;
+      for (let i = 0; i < size; i += 1) {
         dist[i] = [];
-        for (var j = 0; j < size; j += 1) {
+        for (let j = 0; j < size; j += 1) {
           if (i === j) {
             dist[i][j] = 0;
           } else if (!isFinite(graph[i][j])) {
@@ -65,10 +65,10 @@
      */
     return function (graph) {
       dist = init(graph);
-      var size = graph.length;
-      for (var k = 0; k < size; k += 1) {
-        for (var i = 0; i < size; i += 1) {
-          for (var j = 0; j < size; j += 1) {
+      let size = graph.length;
+      for (let k = 0; k < size; k += 1) {
+        for (let i = 0; i < size; i += 1) {
+          for (let j = 0; j < size; j += 1) {
             if (dist[i][j] > dist[i][k] + dist[k][j]) {
               dist[i][j] = dist[i][k] + dist[k][j];
             }

--- a/src/graphs/spanning-trees/kruskal.js
+++ b/src/graphs/spanning-trees/kruskal.js
@@ -3,8 +3,8 @@
 (function(exports) {
   'use strict';
 
-  var QuickUnion = require('../../sets/quickunion').QuickUnion;
-  var mergeSort = require('../../sorting/mergesort').mergeSort;
+  let QuickUnion = require('../../sets/quickunion').QuickUnion;
+  let mergeSort = require('../../sorting/mergesort').mergeSort;
   exports.Vertex = require('../../data-structures/vertex').Vertex;
   exports.Edge = require('../../data-structures/edge').Edge;
 
@@ -13,9 +13,9 @@
   }
 
   exports.Graph.prototype.kruskal = (function () {
-    var qunion;
-    var spanningTree;
-    var indexes;
+    let qunion;
+    let spanningTree;
+    let indexes;
 
     /**
      * Used for sorting the edges
@@ -37,8 +37,8 @@
      * @private
      */
     function init() {
-      var edge;
-      var i = 0;
+      let edge;
+      let i = 0;
 
       mergeSort(this.edges, compareEdges);
       spanningTree = [];
@@ -62,11 +62,11 @@
     return function () {
       init.call(this);
 
-      var edge;
+      let edge;
 
       for (edge of this.edges) {
-        var from = indexes[edge.from.id];
-        var to = indexes[edge.to.id];
+        let from = indexes[edge.from.id];
+        let to = indexes[edge.to.id];
         if (!qunion.connected(from, to)) {
           qunion.union(from, to);
           spanningTree.push(edge);

--- a/src/graphs/spanning-trees/prim.js
+++ b/src/graphs/spanning-trees/prim.js
@@ -44,7 +44,7 @@
 
   'use strict';
 
-  var Heap = require('../../data-structures/heap').Heap;
+  let Heap = require('../../data-structures/heap').Heap;
   exports.Vertex = require('../../data-structures/vertex').Vertex;
   exports.Edge = require('../../data-structures/edge').Edge;
 
@@ -69,7 +69,7 @@
    * @return {Graph} Graph which is the minimum spanning tree.
    */
   exports.Graph.prototype.prim = (function () {
-    var queue;
+    let queue;
 
     /**
      * Used for comparitions in the heap
@@ -96,12 +96,12 @@
 
     return function () {
       init.call(this);
-      var inTheTree = {};
-      var startVertex = this.edges[0].e.id;
-      var spannigTree = [];
-      var parents = {};
-      var distances = {};
-      var current;
+      let inTheTree = {};
+      let startVertex = this.edges[0].e.id;
+      let spannigTree = [];
+      let parents = {};
+      let distances = {};
+      let current;
       inTheTree[startVertex] = true;
       queue.add({
         node: startVertex,
@@ -111,8 +111,8 @@
         if (inTheTree[e.v.id] && inTheTree[e.e.id]) {
           return;
         }
-        var collection = queue.getCollection();
-        var node;
+        let collection = queue.getCollection();
+        let node;
         if (e.e.id === current) {
           node = e.v.id;
         } else if (e.v.id === current) {
@@ -120,7 +120,7 @@
         } else {
           return;
         }
-        for (var i = 0; i < collection.length; i += 1) {
+        for (let i = 0; i < collection.length; i += 1) {
           if (collection[i].node === node) {
             if (collection[i].distance > e.distance) {
               queue.changeKey(i, {
@@ -140,12 +140,12 @@
         parents[node] = current;
         distances[node] = e.distance;
       };
-      for (var i = 0; i < this.nodesCount - 1; i += 1) {
+      for (let i = 0; i < this.nodesCount - 1; i += 1) {
         current = queue.extract().node;
         inTheTree[current] = true;
         this.edges.forEach(process);
       }
-      for (var node in parents) {
+      for (let node in parents) {
         spannigTree.push(
           new exports.Edge(node, parents[node], distances[node]));
       }

--- a/src/others/fibonacci.js
+++ b/src/others/fibonacci.js
@@ -22,9 +22,9 @@
     if (n > 97) {
       throw 'Input too large, results in inaccurate fibonacci value.';
     }
-    var n1 = 0;
-    var n2 = 1;
-    var aux;
+    let n1 = 0;
+    let n2 = 1;
+    let aux;
 
     while (n > 0) {
       aux = n1;

--- a/src/others/fibonacciMemory.js
+++ b/src/others/fibonacciMemory.js
@@ -16,17 +16,17 @@
  * @module others/fibonacciMemory
 */
 (function (exports) {
-    'use strict';
+  'use strict';
 
-    function fibonacciMemory(n) {
-        var i = 0;
-        var aux = [0, 1];
-        while (n != i) {
-            aux[i + 2] = aux[i] + aux[i + 1];
-            i++;
-        }
-        return aux[i];
+  function fibonacciMemory(n) {
+    let i = 0;
+    let aux = [0, 1];
+    while (n !== i) {
+      aux[i + 2] = aux[i] + aux[i + 1];
+      i += 1;
     }
+    return aux[i];
+  }
 
-    exports.fibonacciMemory = fibonacciMemory;
+  exports.fibonacciMemory = fibonacciMemory;
 })(typeof window === 'undefined' ? module.exports : window);

--- a/src/others/levenshtein-distance.js
+++ b/src/others/levenshtein-distance.js
@@ -1,13 +1,13 @@
 (function (exports) {
   'use strict';
 
-  var levenshteinDistance = (function () {
+  let levenshteinDistance = (function () {
 
     function levenshteinDistance (s, ls, t, lt) {
-      var memo = [];
-      var currRowMemo;
-      var i;
-      var k;
+      let memo = [];
+      let currRowMemo;
+      let i;
+      let k;
 
       for (k = 0; k <= lt; k += 1) {
         memo[k] = k;

--- a/src/others/min-coins-change.js
+++ b/src/others/min-coins-change.js
@@ -23,20 +23,20 @@
    *  list, required for the change.
    */
   function minCoinsChange(coins, change) {
-    var minChange = [[0]];
+    let minChange = [[0]];
     if (coins.indexOf(change) >= 0) {
       return [change];
     }
-    for (var i = 1; i <= change; i += 1) {
-      for (var j = 0; j < coins.length && coins[j] <= change; j += 1) {
-        for (var k = 0; k < minChange.length; k += 1) {
+    for (let i = 1; i <= change; i += 1) {
+      for (let j = 0; j < coins.length && coins[j] <= change; j += 1) {
+        for (let k = 0; k < minChange.length; k += 1) {
           if (k + coins[j] === i) {
             minChange[i] = minChange[k].concat([coins[j]]);
           }
         }
       }
     }
-    var result = minChange[change];
+    let result = minChange[change];
     if (!result) {
       return undefined;
     }

--- a/src/others/minkowski-distance.js
+++ b/src/others/minkowski-distance.js
@@ -1,11 +1,11 @@
 (function (exports) {
   'use strict';
 
-  var minkowskiDistance = (function () {
+  let minkowskiDistance = (function () {
 
     function chebyshevDistance (x, y, lx, p, mathfn) {
-      var ret = -p;
-      var i;
+      let ret = -p;
+      let i;
 
       for (i = 0; i < lx; i += 1) {
         ret = mathfn(ret, Math.abs(x[i] - y[i]));
@@ -15,8 +15,8 @@
     }
 
     function minkowskiDistance (x, lx, y, ly, p) {
-      var d;
-      var i;
+      let d;
+      let i;
 
       if (lx !== ly) {
         throw 'Both vectors should have same dimension';

--- a/src/primes/is-prime.js
+++ b/src/primes/is-prime.js
@@ -29,8 +29,8 @@
       return (number === 3);
     }
 
-    var horizon = Math.floor(Math.sqrt(number));
-    var factor = 5;
+    let horizon = Math.floor(Math.sqrt(number));
+    let factor = 5;
 
     while (factor <= horizon) {
 

--- a/src/primes/prime-factor-tree.js
+++ b/src/primes/prime-factor-tree.js
@@ -18,8 +18,8 @@
    * console.log(primeFactorTree(600851475143)); // [71, 839, 1471, 6857]
    */
   exports.primeFactorTree = function (number) {
-    var array = [];
-    var s = 6;
+    let array = [];
+    let s = 6;
     while (number > 1 && number % 2 === 0) {
       number /= 2;
       array.push(2);
@@ -29,8 +29,8 @@
       array.push(3);
     }
     while (number > 4) {
-      var p = s - 1;
-      var q = s + 1;
+      let p = s - 1;
+      let q = s + 1;
       while (number > 4 && number % p === 0) {
         number /= p;
         array.push(p);

--- a/src/primes/sieve-of-atkins.js
+++ b/src/primes/sieve-of-atkins.js
@@ -32,14 +32,14 @@
 
     const testingLimit = Math.ceil(Math.sqrt(limit));
 
-    var i;
-    var j;
-    var n;
+    let i;
+    let j;
+    let n;
 
     for (i = 1; i < testingLimit; i += 1) {
-      var ii = i * i;
+      let ii = i * i;
       for (j = 1; j < testingLimit; j += 1) {
-        var jj = j * j;
+        let jj = j * j;
         if (ii + jj >= limit) {
 	  break;
         }

--- a/src/primes/sieve-of-eratosthenes.js
+++ b/src/primes/sieve-of-eratosthenes.js
@@ -24,10 +24,10 @@
    * console.log(sieveOfEratosthenes(12)); // [2, 3, 5, 7, 11]
    */
   exports.sieveOfEratosthenes = function (limit) {
-    var sieve = [];
-    var primes = [];
-    var k;
-    var l;
+    let sieve = [];
+    let primes = [];
+    let k;
+    let l;
 
     sieve[1] = false;
 

--- a/src/searching/binarysearch.js
+++ b/src/searching/binarysearch.js
@@ -24,11 +24,11 @@
   function binarySearch(array, value, key) {
     key = !key ? id : typeof key === 'string' ? get(key) : key;
     value = key(value);
-    var middle = Math.floor(array.length / 2);
-    var left = 0;
-    var right = array.length;
+    let middle = Math.floor(array.length / 2);
+    let left = 0;
+    let right = array.length;
     while (right >= left) {
-      var middleValue = key(array[middle]);
+      let middleValue = key(array[middle]);
       if (middleValue === value) {
         return middle;
       } else if (middleValue > value) {

--- a/src/searching/knuth-morris-pratt.js
+++ b/src/searching/knuth-morris-pratt.js
@@ -1,14 +1,14 @@
 (function (exports) {
   'use strict';
 
-  var kmp = (function () {
+  let kmp = (function () {
     function builtKMPTable(str) {
-      var res = [];
-      var len;
-      var front;
-      var end;
-      var found;
-      for (var i = 1; i <= str.length; i += 1) {
+      let res = [];
+      let len;
+      let front;
+      let end;
+      let found;
+      for (let i = 1; i <= str.length; i += 1) {
         front = Math.max(1, i - ((res[i - 2] || 0) + 1));
         end = Math.min(i - 1, (res[i - 2] || 0) + 1);
         found = false;
@@ -49,9 +49,9 @@
       if (str === substr) {
         return 0;
       }
-      var table = builtKMPTable(substr);
-      var i = 0;
-      var j = 0;
+      let table = builtKMPTable(substr);
+      let i = 0;
+      let j = 0;
       while (i < str.length) {
         if (str[i] === substr[j]) {
           i += 1;

--- a/src/searching/linearSearch.js
+++ b/src/searching/linearSearch.js
@@ -1,24 +1,24 @@
 (function (exports) {
-    'use strict';
+  'use strict';
 
     /**
      * Searches for specific element in a given array
      * using the linear search algorithm
      * Time complexity: O(n)
-     * 
+     *
      * @param {Array} array Input array
      * @param {Number} key the number whose index is to be found
      * @returns {Number} the index of the first instance of number or else -1 if not found
      */
 
-    const linearSearch = (array, key) => {
-        for (let i = 0; i < array.length; i++) {
-            if (array[i] == key) {
-                return i;
-            }
-        }
-        return -1;
+  const linearSearch = (array, key) => {
+    for (let i = 0; i < array.length; i += 1) {
+      if (array[i] === key) {
+        return i;
+      }
     }
+    return -1;
+  }
 
-    exports.linearSearch = linearSearch;
+  exports.linearSearch = linearSearch;
 })(typeof window === 'undefined' ? module.exports : window);

--- a/src/searching/longest-common-subsequence.js
+++ b/src/searching/longest-common-subsequence.js
@@ -17,10 +17,10 @@
      *
      */
     function getLcsLengths(str1, str2) {
-      var result = [];
-      for (var i = -1; i < str1.length; i = i + 1) {
+      let result = [];
+      for (let i = -1; i < str1.length; i = i + 1) {
         result[i] = [];
-        for (var j = -1; j < str2.length; j = j + 1) {
+        for (let j = -1; j < str2.length; j = j + 1) {
           if (i === -1 || j === -1) {
             result[i][j] = 0;
           } else if (str1[i] === str2[j]) {
@@ -47,7 +47,7 @@
      *
      */
     function getLcs(str1, str2, lcsLengthsMatrix) {
-      var execute = function (i, j) {
+      const execute = function (i, j) {
         if (!lcsLengthsMatrix[i][j]) {
           return '';
         } else if (str1[i] === str2[j]) {
@@ -78,7 +78,7 @@
      * @return {Array} Longest common subsequence.
      */
     return function (str1, str2) {
-      var lcsLengthsMatrix = getLcsLengths(str1, str2);
+      let lcsLengthsMatrix = getLcsLengths(str1, str2);
       return getLcs(str1, str2, lcsLengthsMatrix);
     };
   })();

--- a/src/searching/longest-increasing-subsequence.js
+++ b/src/searching/longest-increasing-subsequence.js
@@ -16,8 +16,8 @@
       if (!array || !array.length) {
         return -1;
       }
-      var maxIdx = 0;
-      for (var i = 1; i < array.length; i += 1) {
+      let maxIdx = 0;
+      for (let i = 1; i < array.length; i += 1) {
         if (array[maxIdx].distance < array[i].distance) {
           maxIdx = i;
         }
@@ -44,10 +44,10 @@
     * @return {Object} Graph represented with list of neighbours.
     */
     function buildDag(array, cmp) {
-      var result = [];
-      for (var i = 0; i < array.length; i += 1) {
+      let result = [];
+      for (let i = 0; i < array.length; i += 1) {
         result[i] = [];
-        for (var j = i + 1; j < array.length; j += 1) {
+        for (let j = i + 1; j < array.length; j += 1) {
           if (cmp(array[i], array[j]) < 0) {
             result[i].push(j);
           }
@@ -69,18 +69,18 @@
       if (find.memo[node]) {
         return find.memo[node];
       }
-      var neighbours = dag[node];
-      var neighboursDistance = [];
-      var maxDist;
+      let neighbours = dag[node];
+      let neighboursDistance = [];
+      let maxDist;
       // var maxNode;
-      var distance;
-      var result;
+      let distance;
+      let result;
 
       if (!neighbours.length) {
         return { distance: 1, neighbour: undefined, node: node };
       }
 
-      for (var i = 0; i < neighbours.length; i += 1) {
+      for (let i = 0; i < neighbours.length; i += 1) {
         neighboursDistance[i] = find(dag, neighbours[i]);
       }
 
@@ -114,11 +114,11 @@
     */
     return function (array, cmp) {
       cmp = cmp || asc;
-      var results = [];
-      var dag = buildDag(array, cmp);
-      var maxPath;
+      let results = [];
+      let dag = buildDag(array, cmp);
+      let maxPath;
       find.memo = [];
-      for (var i = 0; i < array.length; i += 1) {
+      for (let i = 0; i < array.length; i += 1) {
         results.push(find(dag, i));
       }
       maxPath = results[max(results)];

--- a/src/searching/maximum-subarray-divide-and-conquer.js
+++ b/src/searching/maximum-subarray-divide-and-conquer.js
@@ -12,10 +12,10 @@
    * @return {Number} The maximum sum including the middle element.
    */
   function crossSubarray(array, left, middle, right) {
-    var leftSum = -Infinity;
-    var rightSum = -Infinity;
-    var sum = 0;
-    var i;
+    let leftSum = -Infinity;
+    let rightSum = -Infinity;
+    let sum = 0;
+    let i;
 
     for (i = middle; i >= left; i -= 1) {
       if (sum + array[i] >= leftSum) {
@@ -45,10 +45,10 @@
     if (right - left <= 1) {
       return array[left];
     }
-    var middle = Math.floor((left + right) / 2);
-    var leftSum = maxSubarrayPartitioner(array, left, middle);
-    var rightSum = maxSubarrayPartitioner(array, middle, right);
-    var crossSum = crossSubarray(array, left, middle, right);
+    let middle = Math.floor((left + right) / 2);
+    let leftSum = maxSubarrayPartitioner(array, left, middle);
+    let rightSum = maxSubarrayPartitioner(array, middle, right);
+    let crossSum = crossSubarray(array, left, middle, right);
 
     return Math.max(crossSum, leftSum, rightSum);
   }

--- a/src/searching/maximum-subarray.js
+++ b/src/searching/maximum-subarray.js
@@ -20,9 +20,9 @@
    * @return {Number} Maximum sum of the elements of a subarray.
    */
   function maxSubarray(array) {
-    var currentMax = array[0];
-    var max = array[0];
-    for (var i = 1; i < array.length; i += 1) {
+    let currentMax = array[0];
+    let max = array[0];
+    for (let i = 1; i < array.length; i += 1) {
       currentMax = Math.max(array[i], currentMax + array[i]);
       max = Math.max(max, currentMax);
     }

--- a/src/searching/quickselect.js
+++ b/src/searching/quickselect.js
@@ -24,13 +24,13 @@
   function quickselect(arr, n, lo, hi) {
     function partition(arr, lo, hi, pivotIdx) {
       function swap(arr, i, j) {
-        var temp = arr[i];
+        let temp = arr[i];
         arr[i] = arr[j];
         arr[j] = temp;
       }
-      var pivot = arr[pivotIdx];
+      let pivot = arr[pivotIdx];
       swap(arr, pivotIdx, hi);
-      for (var i = lo; i < hi; i += 1) {
+      for (let i = lo; i < hi; i += 1) {
         if (arr[i] < pivot) {
           swap(arr, i, lo);
           lo += 1;
@@ -49,7 +49,7 @@
       return arr[lo];
     }
     while (hi >= lo) {
-      var pivotIdx =
+      let pivotIdx =
       partition(arr, lo, hi, lo + Math.floor(Math.random() * (hi - lo + 1)));
       if (n === pivotIdx) {
         return arr[pivotIdx];

--- a/src/searching/recursive-binarysearch.js
+++ b/src/searching/recursive-binarysearch.js
@@ -1,7 +1,7 @@
 (function (exports) {
   'use strict';
 
-  var binarySearch = (function () {
+  let binarySearch = (function () {
     /**
      * @private
      * @param {Array} array Array where we should find the index of the element
@@ -14,7 +14,7 @@
       if (left > right) {
         return -1;
       }
-      var middle = Math.floor((right + left) / 2);
+      let middle = Math.floor((right + left) / 2);
       if (array[middle] === value) {
         return middle;
       } else if (array[middle] > value) {

--- a/src/sets/quickfind.js
+++ b/src/sets/quickfind.js
@@ -37,7 +37,7 @@
    */
   exports.QuickFind = function (size) {
     this._ids = [];
-    for (var i = 0; i < size; i += 1) {
+    for (let i = 0; i < size; i += 1) {
       this._ids[i] = i;
     }
   };
@@ -52,10 +52,10 @@
    * @param {Number} q The second node.
    */
   exports.QuickFind.prototype.union = function (p, q) {
-    var size = this._ids.length;
-    var pval = this._ids[p];
-    var qval = this._ids[q];
-    for (var i = 0; i < size; i += 1) {
+    let size = this._ids.length;
+    let pval = this._ids[p];
+    let qval = this._ids[q];
+    for (let i = 0; i < size; i += 1) {
       if (this._ids[i] === qval) {
         this._ids[i] = pval;
       }

--- a/src/sets/quickunion.js
+++ b/src/sets/quickunion.js
@@ -38,7 +38,7 @@
    */
   exports.QuickUnion = function (n) {
     this._ids = [];
-    for (var i = 0; i < n; i += 1) {
+    for (let i = 0; i < n; i += 1) {
       this._ids[i] = i;
     }
   };
@@ -67,8 +67,8 @@
    * @param {Number} q The second node.
    */
   exports.QuickUnion.prototype.union = function (p, q) {
-    var pRoot = this._root(p);
-    var qRoot = this._root(q);
+    let pRoot = this._root(p);
+    let qRoot = this._root(q);
     this._ids[pRoot] = qRoot;
   };
 

--- a/src/sets/weightquickunion.js
+++ b/src/sets/weightquickunion.js
@@ -39,7 +39,7 @@
   exports.QuickUnion = function (n) {
     this._ids = [];
     this._size = [];
-    for (var i = 0; i < n; i += 1) {
+    for (let i = 0; i < n; i += 1) {
       this._ids[i] = i;
       this._size[i] = 1;
     }
@@ -82,13 +82,13 @@
   * @param {Number} q The second node.
   */
   exports.QuickUnion.prototype.union = function (p, q) {
-    var pf = this._root(p);
-    var qf = this._root(q);
+    let pf = this._root(p);
+    let qf = this._root(q);
     if (pf === qf) {
       return; // already linked
     }
-    var psz = this._size[qf];
-    var qsz = this._size[pf];
+    let psz = this._size[qf];
+    let qsz = this._size[pf];
     if (psz < qsz) {
       this._ids[pf] = qf;
       this._size[qf] += psz;

--- a/src/shuffle/fisheryates.js
+++ b/src/shuffle/fisheryates.js
@@ -18,9 +18,9 @@
    * @return {Array} Shuffled array.
    */
   function shuffle(array) {
-    var size = array.length;
-    var rand;
-    for (var i = 0; i < size; i += 1) {
+    let size = array.length;
+    let rand;
+    for (let i = 0; i < size; i += 1) {
       rand = Math.floor(i + Math.random() * (size - i));
       [array[rand], array[i]] = [array[i], array[rand]];
     }

--- a/src/shuffle/richarddurstenfeld.js
+++ b/src/shuffle/richarddurstenfeld.js
@@ -19,10 +19,10 @@
    * @return {Array} Shuffled array.
    */
   function shuffle(array) {
-    var arraySize = array.length - 1;
-    var rand;
-    var temp;
-    for (var i = arraySize; i >= 0; i -= 1) {
+    let arraySize = array.length - 1;
+    let rand;
+    let temp;
+    for (let i = arraySize; i >= 0; i -= 1) {
       rand = Math.round(Math.random() * arraySize);
       temp = array[i];
       array[i] = array[rand];

--- a/src/sorting/3-way-string-quicksort.js
+++ b/src/sorting/3-way-string-quicksort.js
@@ -1,14 +1,14 @@
 (function (exports) {
   'use strict';
 
-  var quicksort = (function () {
+  let quicksort = (function () {
 
     function charAt(str, i) {
       return (i < str.length) ? str.charCodeAt(i) : -1;
     }
 
     function swap(arr, i, j) {
-      var temp = arr[j];
+      let temp = arr[j];
       arr[j] = arr[i];
       arr[i] = temp;
     }
@@ -17,11 +17,11 @@
       if (lo >= hi) {
         return;
       }
-      var lowPointer = lo;
-      var highPointer = hi;
-      var p = charAt(arr[lo], d);
-      var i = lo + 1;
-      var current;
+      let lowPointer = lo;
+      let highPointer = hi;
+      let p = charAt(arr[lo], d);
+      let i = lo + 1;
+      let current;
 
       while (i <= highPointer) {
         current = charAt(arr[i], d);

--- a/src/sorting/bubblesort.js
+++ b/src/sorting/bubblesort.js
@@ -24,10 +24,10 @@
    */
   function bubbleSort(array, cmp) {
     cmp = cmp || comparator;
-    var temp;
-    for (var i = 0; i < array.length - 1 ; i += 1) {
-      var swapCount = 0;
-      for (var j = 0; j < array.length - 1 - i; j += 1) {
+    let temp;
+    for (let i = 0; i < array.length - 1 ; i += 1) {
+      let swapCount = 0;
+      for (let j = 0; j < array.length - 1 - i; j += 1) {
         if (cmp(array[j], array[j + 1 ]) > 0) {
           temp = array[j];
           array[j] = array[j + 1];

--- a/src/sorting/bucketsort.js
+++ b/src/sorting/bucketsort.js
@@ -2,7 +2,7 @@
 
   'use strict';
 
-  var bucketSort = (function () {
+  let bucketSort = (function () {
 
     /**
      * Insertionsort.
@@ -12,9 +12,9 @@
      * @returns {array} array Sorted input array
      */
     function insertionSort(array) {
-      var current;
-      var j;
-      for (var i = 1; i < array.length; i += 1) {
+      let current;
+      let j;
+      for (let i = 1; i < array.length; i += 1) {
         current = array[i];
         j = i - 1;
         while (j >= 0 && current < array[j]) {
@@ -36,10 +36,10 @@
      *                          from the input which are with suitable size.
      */
     function createBuckets(array) {
-      var buckets = [];
-      var currentBucket;
-      var current;
-      for (var i = 0; i < array.length; i += 1) {
+      let buckets = [];
+      let currentBucket;
+      let current;
+      for (let i = 0; i < array.length; i += 1) {
         current = array[i];
         currentBucket = Math.floor(current);
         buckets[currentBucket] = buckets[currentBucket] || [];
@@ -56,7 +56,7 @@
      * @returns {array} buckets Buckets with sorted arrays for each bucket
      */
     function sortBuckets(buckets) {
-      for (var i = 0; i < buckets.length; i += 1) {
+      for (let i = 0; i < buckets.length; i += 1) {
         if (buckets[i] !== undefined) {
           insertionSort(buckets[i]);
         }
@@ -73,9 +73,9 @@
      *                         all elements form each bucket
      */
     function unionBuckets(buckets) {
-      var result = [];
-      var currentBucket;
-      for (var i = 0; i < buckets.length; i += 1) {
+      let result = [];
+      let currentBucket;
+      for (let i = 0; i < buckets.length; i += 1) {
         currentBucket = buckets[i];
         if (currentBucket !== undefined) {
           result = result.concat(currentBucket);
@@ -101,7 +101,7 @@
      * @return {Array} Sorted array.
      */
     return function (array) {
-      var buckets = createBuckets(array);
+      let buckets = createBuckets(array);
       sortBuckets(buckets);
       return unionBuckets(buckets);
     };

--- a/src/sorting/countingsort.js
+++ b/src/sorting/countingsort.js
@@ -1,7 +1,7 @@
 (function (exports) {
   'use strict';
 
-  var countingSort = (function () {
+  let countingSort = (function () {
 
     /**
      * Gets the count of the elements into the input array.
@@ -11,9 +11,9 @@
      * @return {Array} The count of each element from the input array.
      */
     function getCount(array) {
-      var count = [];
-      var current;
-      for (var i = 0; i < array.length; i += 1) {
+      let count = [];
+      let current;
+      for (let i = 0; i < array.length; i += 1) {
         current = array[i];
         count[current] = (count[current] || 0) + 1;
       }
@@ -29,10 +29,10 @@
      * are less than each element from the input.
      */
     function getLessCount(array) {
-      var less = [];
-      var last;
+      let less = [];
+      let last;
       less[0] = array[0] || 0;
-      for (var i = 1; i < array.length; i += 1) {
+      for (let i = 1; i < array.length; i += 1) {
         last = array[i - 1] || 0;
         less[i] = last + less[i - 1];
       }
@@ -48,11 +48,11 @@
      * @return {Array} The sorted input.
      */
     function sort(array, less) {
-      var result = [];
-      var currentPositions = [];
-      var current;
-      var position;
-      for (var i = 0; i < array.length; i += 1) {
+      let result = [];
+      let currentPositions = [];
+      let current;
+      let position;
+      for (let i = 0; i < array.length; i += 1) {
         current = array[i];
         position = less[current];
         if (currentPositions[current] === undefined) {
@@ -80,7 +80,7 @@
      * @return {Array} Sorted array.
      */
     return function (array) {
-      var less = getLessCount(getCount(array));
+      let less = getLessCount(getCount(array));
       return sort(array, less);
     };
   }());

--- a/src/sorting/heapsort.js
+++ b/src/sorting/heapsort.js
@@ -5,7 +5,7 @@
     return a - b;
   }
 
-  var heapSort = (function () {
+  let heapSort = (function () {
 
     /**
      * Finds the correct place of given element in given max heap.
@@ -18,9 +18,9 @@
      * @param {function} cmp Comparison function.
      */
     function heapify(array, index, heapSize, cmp) {
-      var left = 2 * index + 1;
-      var right = 2 * index + 2;
-      var largest = index;
+      let left = 2 * index + 1;
+      let right = 2 * index + 2;
+      let largest = index;
 
       if (left < heapSize && cmp(array[left], array[index]) > 0) {
         largest = left;
@@ -31,7 +31,7 @@
       }
 
       if (largest !== index) {
-        var temp = array[index];
+        let temp = array[index];
         array[index] = array[largest];
         array[largest] = temp;
         heapify(array, largest, heapSize, cmp);
@@ -47,7 +47,7 @@
      * @return {Array} array Array turned into max heap.
      */
     function buildMaxHeap(array, cmp) {
-      for (var i = Math.floor(array.length / 2); i >= 0; i -= 1) {
+      for (let i = Math.floor(array.length / 2); i >= 0; i -= 1) {
         heapify(array, i, array.length, cmp);
       }
       return array;
@@ -74,10 +74,10 @@
      */
     return function (array, cmp) {
       cmp = cmp || comparator;
-      var size = array.length;
-      var temp;
+      let size = array.length;
+      let temp;
       buildMaxHeap(array, cmp);
-      for (var i = array.length - 1; i > 0; i -= 1) {
+      for (let i = array.length - 1; i > 0; i -= 1) {
         temp = array[0];
         array[0] = array[i];
         array[i] = temp;

--- a/src/sorting/insertion-binary-sort.js
+++ b/src/sorting/insertion-binary-sort.js
@@ -28,11 +28,11 @@
    */
   function insertionBinarySort(array, cmp) {
     cmp = cmp || comparator;
-    var current;
-    var middle;
-    var left;
-    var right;
-    for (var i = 1; i < array.length; i += 1) {
+    let current;
+    let middle;
+    let left;
+    let right;
+    for (let i = 1; i < array.length; i += 1) {
       current = array[i];
       left = 0;
       right = i;
@@ -45,7 +45,8 @@
         }
         middle = Math.floor((right + left) / 2);
       }
-      for (var j = i; j > left; j -= 1) {
+      let j = i;
+      for (j = i; j > left; j -= 1) {
         array[j] = array[j - 1];
       }
       array[j] = current;

--- a/src/sorting/insertionsort.js
+++ b/src/sorting/insertionsort.js
@@ -25,9 +25,9 @@
    */
   function insertionSort(array, cmp) {
     cmp = cmp || compare;
-    var current;
-    var j;
-    for (var i = 1; i < array.length; i += 1) {
+    let current;
+    let j;
+    for (let i = 1; i < array.length; i += 1) {
       current = array[i];
       j = i - 1;
       while (j >= 0 && cmp(array[j], current) > 0) {

--- a/src/sorting/lsd.js
+++ b/src/sorting/lsd.js
@@ -18,28 +18,28 @@
    * @return {Array} Sorted array.
    */
   function lsd(arr, letterIdx) {
-    var temp;
-    var count;
+    let temp;
+    let count;
     letterIdx = letterIdx || 1;
-    for (var i = letterIdx - 1; i >= 0; i -= 1) {
+    for (let i = letterIdx - 1; i >= 0; i -= 1) {
       count = [];
       temp = [];
-      for (var j = 0; j < arr.length; j += 1) {
-        var charCode = arr[j].charCodeAt(i);
-        var old = count[charCode + 1] || 0;
+      for (let j = 0; j < arr.length; j += 1) {
+        let charCode = arr[j].charCodeAt(i);
+        let old = count[charCode + 1] || 0;
         count[charCode + 1] = old + 1;
       }
-      for (var c = 0; c < count.length - 1; c += 1) {
+      for (let c = 0; c < count.length - 1; c += 1) {
         count[c] = count[c] || 0;
         count[c + 1] = count[c + 1] || 0;
         count[c + 1] += count[c];
       }
-      for (j = 0; j < arr.length; j += 1) {
-        var code = arr[j].charCodeAt(i);
+      for (let j = 0; j < arr.length; j += 1) {
+        let code = arr[j].charCodeAt(i);
         temp[count[code]] = arr[j];
         count[code] += 1;
       }
-      for (j = 0; j < arr.length; j += 1) {
+      for (let j = 0; j < arr.length; j += 1) {
         arr[j] = temp[j];
       }
     }

--- a/src/sorting/mergesort.js
+++ b/src/sorting/mergesort.js
@@ -4,7 +4,7 @@
    */
   'use strict';
 
-  var ll = require('../data-structures/linked-list.js');
+  let ll = require('../data-structures/linked-list.js');
 
   function compare(a, b) {
     return a - b;
@@ -34,7 +34,7 @@
     if (Math.abs(end - start) <= 1) {
       return [];
     }
-    var middle = Math.ceil((start + end) / 2);
+    let middle = Math.ceil((start + end) / 2);
 
     mergeSort(array, cmp, start, middle);
     mergeSort(array, cmp, middle, end);
@@ -63,14 +63,14 @@
    * }, 0, 4, 7);
    */
   mergeSort.merge = function (array, cmp, start, middle, end) {
-    var left = new ll.LinkedList();
-    var right = new ll.LinkedList();
+    let left = new ll.LinkedList();
+    let right = new ll.LinkedList();
 
-    var leftSize = middle - start;
-    var rightSize = end - middle;
-    var maxSize = Math.max(leftSize, rightSize);
-    var size = end - start;
-    var i;
+    let leftSize = middle - start;
+    let rightSize = end - middle;
+    let maxSize = Math.max(leftSize, rightSize);
+    let size = end - start;
+    let i;
 
     for (i = 0; i < maxSize; i += 1) {
       if (i < leftSize) {

--- a/src/sorting/msd.js
+++ b/src/sorting/msd.js
@@ -6,10 +6,10 @@
   }
 
   function sort(arr, lo, hi, d) {
-    var temp = [];
-    var count = [];
-    var j;
-    var idx;
+    let temp = [];
+    let count = [];
+    let j;
+    let idx;
     // Use Insertion sort when the
     // array is smaller than given threshold
     for (j = lo; j <= hi; j += 1) {

--- a/src/sorting/oddeven-sort.js
+++ b/src/sorting/oddeven-sort.js
@@ -17,22 +17,22 @@
    */
   function oddEvenSort(arr) {
     function swap(arr, i, j) {
-      var temp = arr[i];
+      let temp = arr[i];
       arr[i] = arr[j];
       arr[j] = temp;
     }
 
-    var sorted = false;
+    let sorted = false;
     while (!sorted) {
       sorted = true;
-      for (var i = 1; i < arr.length - 1; i += 2) {
+      for (let i = 1; i < arr.length - 1; i += 2) {
         if (arr[i] > arr[i + 1]) {
           swap(arr, i, i + 1);
           sorted = false;
         }
       }
 
-      for (i = 0; i < arr.length - 1; i += 2) {
+      for (let i = 0; i < arr.length - 1; i += 2) {
         if (arr[i] > arr[i + 1]) {
           swap(arr, i, i + 1);
           sorted = false;

--- a/src/sorting/quicksort-declarative.js
+++ b/src/sorting/quicksort-declarative.js
@@ -13,7 +13,7 @@
    * @param {array} array Array which should be sorted.
    * @return {array} Sorted array.
    */
-  var quickSort = (function () {
+  let quickSort = (function () {
 
     /**
      * Recursively calls itself.

--- a/src/sorting/quicksort-middle.js
+++ b/src/sorting/quicksort-middle.js
@@ -13,7 +13,7 @@
    * @param {array} array Array which should be sorted.
    * @return {array} Sorted array.
    */
-  var quickSort = (function () {
+  let quickSort = (function () {
 
     /**
      * Partitions the array in two parts by the middle elements.
@@ -27,8 +27,8 @@
      * @return {number}
      */
     function partition(array, left, right, cmp) {
-      var pivot = array[Math.floor((left + right) / 2)];
-      var temp;
+      let pivot = array[Math.floor((left + right) / 2)];
+      let temp;
       while (left <= right) {
         while (cmp(array[left], pivot) < 0) {
           left += 1;
@@ -57,7 +57,7 @@
      * @param {number} right Right part of the array which should be processed
      */
     function quicksort(array, left, right, cmp) {
-      var mid = partition(array, left, right, cmp);
+      let mid = partition(array, left, right, cmp);
       if (left < mid - 1) {
         quicksort(array, left, mid - 1, cmp);
       }

--- a/src/sorting/quicksort.js
+++ b/src/sorting/quicksort.js
@@ -7,7 +7,7 @@
    *
    * @public
    */
-  var quickSort = (function () {
+  let quickSort = (function () {
 
     function compare(a, b) {
       return a - b;
@@ -23,7 +23,7 @@
      * @returns {array} array The array with swapped elements
      */
     function swap(array, i, j) {
-      var temp = array[i];
+      let temp = array[i];
       array[i] = array[j];
       array[j] = temp;
       return array;
@@ -38,9 +38,9 @@
      * @param {number} right The end of the subarray
      */
     function partition(array, left, right, compare) {
-      var cmp = array[right - 1];
-      var minEnd = left;
-      var maxEnd;
+      let cmp = array[right - 1];
+      let minEnd = left;
+      let maxEnd;
       for (maxEnd = left; maxEnd < right - 1; maxEnd += 1) {
         if (compare(array[maxEnd], cmp) < 0) {
           swap(array, maxEnd, minEnd);
@@ -62,7 +62,7 @@
      */
     function quickSort(array, left, right, cmp) {
       if (left < right) {
-        var p = partition(array, left, right, cmp);
+        let p = partition(array, left, right, cmp);
         quickSort(array, left, p, cmp);
         quickSort(array, p + 1, right, cmp);
       }

--- a/src/sorting/radixsort.js
+++ b/src/sorting/radixsort.js
@@ -1,7 +1,7 @@
 (function (exports) {
   'use strict';
 
-  var radixSort = (function () {
+  let radixSort = (function () {
 
     /**
      * Returns the digit of a number that is 'lsdOffset'
@@ -16,9 +16,9 @@
      * if lsdOffset is bigger or equal to the number of digits of the 'number'
      * argument.
      */
-    var getDigit = function (number, lsdOffset) {
-      var size = number.toString().length;
-      var digit;
+    let getDigit = function (number, lsdOffset) {
+      let size = number.toString().length;
+      let digit;
 
       if (lsdOffset >= 0 && lsdOffset < size) {
         digit = number.toString()[size - 1 - lsdOffset];
@@ -44,17 +44,17 @@
      * @return {Array} Sorted array
      */
     return function (array) {
-      var size = array.length;
-      var R = 10;   /* Alphabet size ([0-9] for integers) */
-      var count;
-      var digit;
-      var i;
-      var j;
+      let size = array.length;
+      let R = 10;   /* Alphabet size ([0-9] for integers) */
+      let count;
+      let digit;
+      let i;
+      let j;
 
       /* Find maximum key size */
-      var maxKeySize = (array[0] || '').toString().length;
+      let maxKeySize = (array[0] || '').toString().length;
       for (i = 1; i < size; i += 1) {
-        var numStr = array[i].toString();
+        let numStr = array[i].toString();
         if (numStr.length > maxKeySize) {
           maxKeySize = numStr.length;
         }
@@ -79,7 +79,7 @@
         }
 
         /* Move elements to auxiliary array */
-        var aux = [];
+        let aux = [];
         for (j = size - 1; j >= 0; j -= 1) {
           digit = getDigit(array[j], i) || 0;
           count[digit] -= 1;

--- a/src/sorting/recursive-insertionsort.js
+++ b/src/sorting/recursive-insertionsort.js
@@ -34,7 +34,10 @@
       return array;
     }
     recursiveInsertionSort(array, cmp, max - 1);
-    for (var i = max - 1, current = array[max];
+
+    let i;
+    let current;
+    for (i = max - 1, current = array[max];
         i >= 0 && cmp(current, array[i]) < 0; i -= 1) {
       array[i + 1] = array[i];
     }

--- a/src/sorting/selectionsort.js
+++ b/src/sorting/selectionsort.js
@@ -23,13 +23,13 @@
    * zero, or positive value, depending on the arguments.
    * @return {Array} Sorted array.
    */
-  var selectionSort = function (array, cmp) {
+  let selectionSort = function (array, cmp) {
     cmp = cmp || compare;
-    var idx;
-    var temp;
-    for (var i = 0; i < array.length - 1; i += 1) {
+    let idx;
+    let temp;
+    for (let i = 0; i < array.length - 1; i += 1) {
       idx = i;
-      for (var j = i + 1; j < array.length; j += 1) {
+      for (let j = i + 1; j < array.length; j += 1) {
         if (cmp(array[idx], array[j]) > 0) {
           idx = j;
         }

--- a/src/sorting/shellsort.js
+++ b/src/sorting/shellsort.js
@@ -5,9 +5,9 @@
     return a - b;
   }
 
-  var shellSort = (function () {
+  let shellSort = (function () {
 
-    var gaps = [701, 301, 132, 57, 23, 10, 4, 1];
+    let gaps = [701, 301, 132, 57, 23, 10, 4, 1];
 
     /**
      * Shellsort which uses the gaps 701, 301, 132, 57, 23, 10, 4, 1 and
@@ -30,13 +30,14 @@
     return function (array, cmp) {
       cmp = cmp || compare;
 
-      var gap;
-      var current;
-      for (var k = 0; k < gaps.length; k += 1) {
+      let gap;
+      let current;
+      let j;
+      for (let k = 0; k < gaps.length; k += 1) {
         gap = gaps[k];
-        for (var i = gap; i < array.length; i += gap) {
+        for (let i = gap; i < array.length; i += gap) {
           current = array[i];
-          for (var j = i;
+          for (j = i;
               j >= gap && cmp(array[j - gap], current) > 0; j -= gap) {
             array[j] = array[j - gap];
           }

--- a/test/compression/burrows-wheeler/burrows-wheeler.spec.js
+++ b/test/compression/burrows-wheeler/burrows-wheeler.spec.js
@@ -1,4 +1,4 @@
-var bw = require('../../../src/compression/burrows-wheeler/burrows-wheeler').burrowsWheeler;
+let bw = require('../../../src/compression/burrows-wheeler/burrows-wheeler').burrowsWheeler;
 
 describe('Burrows Wheeler', function () {
   'use strict';

--- a/test/data-structures/avl-tree.spec.js
+++ b/test/data-structures/avl-tree.spec.js
@@ -1,6 +1,6 @@
-var mod = require('../../src/data-structures/avl-tree.js');
-var Node = mod.Node;
-var AVLTree = mod.AVLTree;
+let mod = require('../../src/data-structures/avl-tree.js');
+let Node = mod.Node;
+let AVLTree = mod.AVLTree;
 
 describe('Node', function () {
   'use strict';
@@ -20,7 +20,7 @@ describe('AVL Tree', function () {
     expect(new AVLTree()._root).toBe(null);
   });
   it('should insert and single rotate (leftRight) properly', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(66);
     avlTree.insert(3);
     avlTree.insert(5);
@@ -33,7 +33,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._height).toBe(1);
   });
   it('should insert and single rotate (rightLeft) properly', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(50);
     avlTree.insert(75);
     avlTree.insert(60);
@@ -46,7 +46,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._height).toBe(1);
   });
   it('should insert and double rotate (leftLeft) properly', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(50);
     avlTree.insert(25);
     avlTree.insert(10);
@@ -59,7 +59,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._height).toBe(1);
   });
   it('should insert and double rotate (rightRight) properly', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(50);
     avlTree.insert(75);
     avlTree.insert(100);
@@ -72,7 +72,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._height).toBe(1);
   });
   it('should insert multiple nodes and balance properly (1)', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(30);
     avlTree.insert(15);
     avlTree.insert(60);
@@ -91,7 +91,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._right._height).toBe(1);
   });
   it('should insert multiple nodes and balance properly (2)', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(24);
     avlTree.insert(67);
     avlTree.insert(33);
@@ -126,7 +126,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._left._right._right._height).toBe(1);
   });
   it('should remove nodes and balance properly (1)', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(30);
     avlTree.insert(15);
     avlTree.insert(60);
@@ -147,7 +147,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._left._right._height).toBe(1);
   });
   it('should remove nodes and balance properly (2)', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(55);
     avlTree.insert(25);
     avlTree.insert(11);
@@ -164,7 +164,7 @@ describe('AVL Tree', function () {
     expect(avlTree._root._right._height).toBe(1);
   });
   it('should remove nodes and balance properly (3)', function () {
-    var avlTree = new AVLTree();
+    let avlTree = new AVLTree();
     avlTree.insert(55);
     avlTree.insert(25);
     avlTree.insert(11);

--- a/test/data-structures/binary-search-tree.spec.js
+++ b/test/data-structures/binary-search-tree.spec.js
@@ -1,6 +1,6 @@
-var mod = require('../../src/data-structures/binary-search-tree.js');
-var Node = mod.Node;
-var BinaryTree = mod.BinaryTree;
+let mod = require('../../src/data-structures/binary-search-tree.js');
+let Node = mod.Node;
+let BinaryTree = mod.BinaryTree;
 
 describe('Node', function () {
   'use strict';
@@ -20,23 +20,23 @@ describe('Binary Tree', function () {
     expect(new BinaryTree()._root).toBe(null);
   });
   it('should insert and remove single node properly', function () {
-    var bTree = new BinaryTree();
+    let bTree = new BinaryTree();
     bTree.insert(15);
-    var node = bTree.find(15);
+    let node = bTree.find(15);
     bTree.remove(node);
     expect(bTree._root).toBe(null);
   });
   it('should remove root and replace with valid child', function () {
-    var bTree = new BinaryTree();
+    let bTree = new BinaryTree();
     bTree.insert(15);
     bTree.insert(30);
     bTree.insert(45);
-    var node = bTree.find(15);
+    let node = bTree.find(15);
     bTree.remove(node);
     expect(bTree._root.value).toBe(30);
   });
   it('should insert multiple nodes properly', function () {
-    var bTree = new BinaryTree();
+    let bTree = new BinaryTree();
     bTree.insert(10);
     bTree.insert(5);
     bTree.insert(15);
@@ -44,8 +44,8 @@ describe('Binary Tree', function () {
     bTree.insert(6);
     bTree.insert(14);
     bTree.insert(16);
-    var leftRootChild = bTree._root._left;
-    var rightRootChild = bTree._root._right;
+    let leftRootChild = bTree._root._left;
+    let rightRootChild = bTree._root._right;
     expect(bTree._root.value).toBe(10);
     expect(leftRootChild.value).toBe(5);
     expect(rightRootChild.value).toBe(15);
@@ -55,7 +55,7 @@ describe('Binary Tree', function () {
     expect(rightRootChild._right.value).toBe(16);
   });
   it('should remove multiple nodes properly', function () {
-    var bTree = new BinaryTree();
+    let bTree = new BinaryTree();
     bTree.insert(10);
     bTree.insert(5);
     bTree.insert(15);
@@ -64,9 +64,9 @@ describe('Binary Tree', function () {
     bTree.insert(7);
     bTree.insert(14);
     bTree.insert(16);
-    var leftRootChild = bTree._root._left;
-    var rightRootChild = bTree._root._right;
-    var sixteen = bTree.find(16);
+    let leftRootChild = bTree._root._left;
+    let rightRootChild = bTree._root._right;
+    let sixteen = bTree.find(16);
     bTree.remove(sixteen);
     expect(bTree._root.value).toBe(10);
     expect(leftRootChild.value).toBe(5);
@@ -76,10 +76,10 @@ describe('Binary Tree', function () {
     expect(leftRootChild._right._right.value).toBe(7);
     expect(rightRootChild._left.value).toBe(14);
     expect(rightRootChild._right).toBe(null);
-    var fourteen = bTree.find(14);
+    let fourteen = bTree.find(14);
     bTree.remove(fourteen);
     expect(rightRootChild._left).toBe(null);
-    var five = bTree.find(5);
+    let five = bTree.find(5);
     bTree.remove(five);
     expect(leftRootChild.value).toBe(6);
     expect(leftRootChild._left.value).toBe(4);

--- a/test/data-structures/bloomfilter.spec.js
+++ b/test/data-structures/bloomfilter.spec.js
@@ -1,12 +1,12 @@
-var mod = require('../../src/data-structures/bloomfilter.js');
-var Bitmap = mod.Bitmap;
-var Bloomfilter = mod.Bloomfilter;
+let mod = require('../../src/data-structures/bloomfilter.js');
+let Bitmap = mod.Bitmap;
+let Bloomfilter = mod.Bloomfilter;
 
 describe('Bitmap', function() {
   'use strict';
 
   it('should be able to get and set values', function() {
-    var bitmap = new Bitmap(1024);
+    let bitmap = new Bitmap(1024);
     expect(bitmap.exists(0)).toBe(false);
     bitmap.set(0, true);
     expect(bitmap.exists(0)).toBe(true);
@@ -16,8 +16,8 @@ describe('Bitmap', function() {
   });
 
   it('should be able to change everthing back', function() {
-    var bitmap = new Bitmap(2048);
-    for (var i = 0; i < 2048; i = i + 1) {
+    let bitmap = new Bitmap(2048);
+    for (let i = 0; i < 2048; i = i + 1) {
       expect(bitmap.get(i)).toBe(0);
       bitmap.set(i, 1);
       expect(bitmap.get(i)).toBe(1);
@@ -30,7 +30,7 @@ describe('Bitmap', function() {
 describe('Bloomfilter', function() {
   'use strict';
   it('should be able to identify duplicates', function() {
-    var bloomfilter = new Bloomfilter(1024, 0.01);
+    let bloomfilter = new Bloomfilter(1024, 0.01);
     expect(bloomfilter.get('a')).toBe(false);
     expect(bloomfilter.get('b')).toBe(false);
     bloomfilter.set('a');
@@ -42,10 +42,10 @@ describe('Bloomfilter', function() {
   });
 
   it('should handle large amount of data inside', function() {
-    var bloomfilter = new Bloomfilter(4096, 0.001); // high precision
+    let bloomfilter = new Bloomfilter(4096, 0.001); // high precision
 
-    var falsePositive = 0;
-    for (var i = 0; i < 1024; i = i + 1) {
+    let falsePositive = 0;
+    for (let i = 0; i < 1024; i = i + 1) {
       if (bloomfilter.get(i)) {
         falsePositive = falsePositive + 1;
       }

--- a/test/data-structures/hash-table.spec.js
+++ b/test/data-structures/hash-table.spec.js
@@ -1,6 +1,6 @@
-var mod = require('../../src/data-structures/hash-table.js');
-var Node = mod.Node;
-var Hashtable = mod.Hashtable;
+let mod = require('../../src/data-structures/hash-table.js');
+let Node = mod.Node;
+let Hashtable = mod.Hashtable;
 
 describe('Node', function () {
   'use strict';
@@ -20,12 +20,12 @@ describe('Hash table', function () {
     expect(new Hashtable().buckets.length).toBe(0);
   });
   it('should put() K(int):V in table properly.', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value');
     expect(hashTable.buckets[10].data).toBe('value');
   });
   it('should put() K(string):V in table properly.', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('key', 'value');
     /*
       'key' hashCode()'s to 106079. Then the hash is adjusted to fit
@@ -37,7 +37,7 @@ describe('Hash table', function () {
     expect(hashTable.buckets[79].data).toBe('value');
   });
   it('should put() multiple K(int):Vs with hash collisions in properly (1).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     // Same hash so going to same bucket, but different keys. Collision.
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
@@ -52,7 +52,7 @@ describe('Hash table', function () {
     expect(hashTable.buckets[14].next.data).toBe('anotherValue');
   });
   it('should put() multiple K(int):Vs with hash collisions in properly (2).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(77, 'lastValue', 'someHash');
@@ -61,7 +61,7 @@ describe('Hash table', function () {
     expect(hashTable.buckets[14].next.next.data).toBe('lastValue');
   });
   it('should put() multiple K(string):Vs with hash collisions in properly (1).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     // Same hash so going to same bucket, but different keys. Collision.
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
@@ -76,7 +76,7 @@ describe('Hash table', function () {
     expect(hashTable.buckets[14].next.data).toBe('anotherValue');
   });
   it('should put() multiple K(string):Vs with hash collisions in properly (2).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');
@@ -85,64 +85,64 @@ describe('Hash table', function () {
     expect(hashTable.buckets[14].next.next.data).toBe('lastValue');
   });
   it('should get() a K(int):V from table properly.', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value');
     expect(hashTable.get(10)).toBe('value');
   });
   it('should get() a K(string):V from table properly.', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value');
     expect(hashTable.get('keyA')).toBe('value');
   });
   it('should get() a K(int):V with collisions from table properly (1).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     expect(hashTable.get(35, 'someHash')).toBe('anotherValue');
   });
   it('should get() a K(int):V with collisions from table properly (2).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(77, 'lastValue', 'someHash');
     expect(hashTable.get(77, 'someHash')).toBe('lastValue');
   });
   it('should get() a K(int):V with collisions from table properly (3).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(77, 'lastValue', 'someHash');
     expect(hashTable.get(35, 'someHash')).toBe('anotherValue');
   });
   it('should get() a K(int):V with collisions from table properly (4).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(77, 'lastValue', 'someHash');
     expect(hashTable.get(10, 'someHash')).toBe('value');
   });
   it('should get() a K(string):V with collisions from table properly (1).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     expect(hashTable.get('keyB', 'someHash')).toBe('anotherValue');
   });
   it('should get() a K(string):V with collisions from table properly (2).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');
     expect(hashTable.get('keyC', 'someHash')).toBe('lastValue');
   });
   it('should get() a K(string):V with collisions from table properly (3).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');
     expect(hashTable.get('keyB', 'someHash')).toBe('anotherValue');
   });
   it('should get() a K(string):V with collisions from table properly (4).', function () {
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');
@@ -150,14 +150,14 @@ describe('Hash table', function () {
   });
   it('should remove() a K(int):V from table properly (1).', function () {
     // remove only node/link in bucket : (B)
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value');
     hashTable.remove(10);
     expect(hashTable.get(10)).toBe(undefined);
   });
   it('should remove() a K(int):V with collisions from table properly (2).', function () {
     // remove start node/link in bucket : (B) - A
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     expect(hashTable.remove(10, 'someHash')).toBe('value');
@@ -166,7 +166,7 @@ describe('Hash table', function () {
   });
   it('should remove() a K(int):V with collisions from table properly (3).', function () {
     // remove start node/link in bucket : (B) - A - C
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(66, 'lastValue', 'someHash');
@@ -176,7 +176,7 @@ describe('Hash table', function () {
   });
   it('should remove() a K(int):V with collisions from table properly (4).', function () {
     // remove middle node/link in bucket : A - (B) - C
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put(10, 'value', 'someHash');
     hashTable.put(35, 'anotherValue', 'someHash');
     hashTable.put(66, 'lastValue', 'someHash');
@@ -186,14 +186,14 @@ describe('Hash table', function () {
   });
   it('should remove() a K(string):V from table properly (1).', function () {
     // remove only node/link in bucket : (B)
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value');
     hashTable.remove('keyA');
     expect(hashTable.get('keyA')).toBe(undefined);
   });
   it('should remove() a K(string):V with collisions from table properly (2).', function () {
     // remove start node/link in bucket : (B) - A
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     expect(hashTable.remove('keyA', 'someHash')).toBe('value');
@@ -202,7 +202,7 @@ describe('Hash table', function () {
   });
   it('should remove() a K(string):V with collisions from table properly (3).', function () {
     // remove start node/link in bucket : (B) - A - C
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');
@@ -212,7 +212,7 @@ describe('Hash table', function () {
   });
   it('should remove() a K(string):V with collisions from table properly (4).', function () {
     // remove middle node/link in bucket : A - (B) - C
-    var hashTable = new Hashtable();
+    let hashTable = new Hashtable();
     hashTable.put('keyA', 'value', 'someHash');
     hashTable.put('keyB', 'anotherValue', 'someHash');
     hashTable.put('keyC', 'lastValue', 'someHash');

--- a/test/data-structures/heap.spec.js
+++ b/test/data-structures/heap.spec.js
@@ -1,5 +1,5 @@
-var mod = require('../../src/data-structures/heap.js');
-var Heap = mod.Heap;
+let mod = require('../../src/data-structures/heap.js');
+let Heap = mod.Heap;
 
 describe('Heap', function () {
   'use strict';
@@ -8,23 +8,23 @@ describe('Heap', function () {
     expect(typeof Heap).toBe('function');
   });
   it('should have default comparison function', function () {
-    var heap = new Heap();
+    let heap = new Heap();
     expect(typeof heap._cmp).toBe('function');
   });
   it('should add an object properly', function () {
-    var heap = new Heap();
+    let heap = new Heap();
     heap.add(1);
     expect(heap._heap[0]).toBe(1);
   });
   it('should remove an object properly', function () {
-    var heap = new Heap();
+    let heap = new Heap();
     heap.add(1);
-    var res = heap.extract();
+    let res = heap.extract();
     expect(res).toBe(1);
     expect(heap._heap.length).toBe(0);
   });
   it('should add multiple nodes properly', function () {
-    var heap = new Heap();
+    let heap = new Heap();
     heap.add(55);
     heap.add(11);
     heap.add(66);
@@ -33,11 +33,11 @@ describe('Heap', function () {
     expect(heap._heap.indexOf(66)).toBeGreaterThan(-1);
   });
   it('should remove multiple nodes properly (max heap)', function () {
-    var heap = new Heap();
+    let heap = new Heap();
     heap.add(55);
     heap.add(11);
     heap.add(66);
-    var res = heap.extract();
+    let res = heap.extract();
     expect(res).toBe(66);
     res = heap.extract();
     expect(res).toBe(55);
@@ -45,13 +45,13 @@ describe('Heap', function () {
     expect(res).toBe(11);
   });
   it('should remove multiple nodes properly (min heap)', function () {
-    var heap = new Heap(function (a, b) {
+    let heap = new Heap(function (a, b) {
       return b - a;
     });
     heap.add(55);
     heap.add(11);
     heap.add(66);
-    var res = heap.extract();
+    let res = heap.extract();
     expect(res).toBe(11);
     res = heap.extract();
     expect(res).toBe(55);
@@ -59,16 +59,16 @@ describe('Heap', function () {
     expect(res).toBe(66);
   });
   it('should update top node properly', function () {
-    var heap = new Heap(function (a, b) {
+    let heap = new Heap(function (a, b) {
       return a.val - b.val;
     });
-    var objectToUpdate = { val: 66 };
+    let objectToUpdate = { val: 66 };
     heap.add(objectToUpdate);
     heap.add({ val: 11 });
     heap.add({ val: 55 });
     objectToUpdate.val = 0;
     heap.update(objectToUpdate);
-    var res = heap.extract();
+    let res = heap.extract();
     expect(res.val).toBe(55);
     res = heap.extract();
     expect(res.val).toBe(11);
@@ -76,16 +76,16 @@ describe('Heap', function () {
     expect(res.val).toBe(0);
   });
   it('should update bottom node properly', function () {
-    var heap = new Heap(function (a, b) {
+    let heap = new Heap(function (a, b) {
       return a.val - b.val;
     });
-    var objectToUpdate = { val: 0 };
+    let objectToUpdate = { val: 0 };
     heap.add(objectToUpdate);
     heap.add({ val: 11 });
     heap.add({ val: 55 });
     objectToUpdate.val = 66;
     heap.update(objectToUpdate);
-    var res = heap.extract();
+    let res = heap.extract();
     expect(res.val).toBe(66);
     res = heap.extract();
     expect(res.val).toBe(55);

--- a/test/data-structures/interval-tree.spec.js
+++ b/test/data-structures/interval-tree.spec.js
@@ -1,11 +1,11 @@
-var mod = require('../../src/data-structures/interval-tree.js');
-var IntervalTree = mod.IntervalTree;
+let mod = require('../../src/data-structures/interval-tree.js');
+let IntervalTree = mod.IntervalTree;
 
 describe('IntervalTree', function () {
   'use strict';
 
   it('should correctly detect intersections', function () {
-    var it = new IntervalTree();
+    let it = new IntervalTree();
 
     it.add([10383734, 10594186])
     it.add([10383734, 10594186])

--- a/test/data-structures/linked-list.spec.js
+++ b/test/data-structures/linked-list.spec.js
@@ -1,6 +1,6 @@
-var mod = require('../../src/data-structures/linked-list.js');
-var Node = mod.Node;
-var LinkedList = mod.LinkedList;
+let mod = require('../../src/data-structures/linked-list.js');
+let Node = mod.Node;
+let LinkedList = mod.LinkedList;
 
 describe('Node', function () {
   'use strict';
@@ -9,7 +9,7 @@ describe('Node', function () {
     expect(typeof Node).toBe('function');
   });
   it('should construct properly', function () {
-    var node = new Node('data');
+    let node = new Node('data');
     expect(node.data).toBe('data');
     expect(node.next).toBe(null);
     expect(node.prev).toBe(null);
@@ -23,7 +23,7 @@ describe('Linked List', function () {
     expect(typeof LinkedList).toBe('function');
   });
   it('should push properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -37,7 +37,7 @@ describe('Linked List', function () {
     expect(linkedList.last.data).toBe(5);
   });
   it('should pop properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -50,7 +50,7 @@ describe('Linked List', function () {
     expect(linkedList.pop().data).toBe(1);
   });
   it('should shift properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -63,7 +63,7 @@ describe('Linked List', function () {
     expect(linkedList.shift().data).toBe(5);
   });
   it('should reverse properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -77,7 +77,7 @@ describe('Linked List', function () {
     expect(linkedList.shift().data).toBe(1);
   });
   it('should recursive reverse properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -91,7 +91,7 @@ describe('Linked List', function () {
     expect(linkedList.shift().data).toBe(1);
   });
   it('should unshift properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -106,9 +106,9 @@ describe('Linked List', function () {
     expect(linkedList.shift().data).toBe(5);
   });
   it('should properly check for existing cycle', function () {
-    var linkedList = new LinkedList();
-    var last = new Node(2);
-    var first = new Node(1);
+    let linkedList = new LinkedList();
+    let last = new Node(2);
+    let first = new Node(1);
     last.next = first;
     last.prev = first;
     first.next = last;
@@ -118,7 +118,7 @@ describe('Linked List', function () {
     expect(linkedList.hasCycle()).toBe(true);
   });
   it('should properly check for non existing cycle', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -127,13 +127,13 @@ describe('Linked List', function () {
     expect(linkedList.hasCycle()).toBe(false);
   });
   it('should inorder properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
     linkedList.push(4);
     linkedList.push(5);
-    var pushedValue = 1;
+    let pushedValue = 1;
     function callback(node){
       expect(node.data).toBe(pushedValue);
       pushedValue += 1;
@@ -141,7 +141,7 @@ describe('Linked List', function () {
     linkedList.inorder(callback);
   });
   it('should delete data properly', function () {
-    var linkedList = new LinkedList();
+    let linkedList = new LinkedList();
     linkedList.push(1);
     linkedList.push(2);
     linkedList.push(3);
@@ -155,18 +155,18 @@ describe('Linked List', function () {
     expect(linkedList.last.data).toBe(5);
   });
   it('should delete complex data properly', function () {
-    var linkedList = new LinkedList();
-    var item1 = {id: 1};
-    var item2 = {id: 2};
-    var item3 = {id: 3};
-    var item4 = {id: 4};
-    var item5 = {id: 5};
+    let linkedList = new LinkedList();
+    let item1 = {id: 1};
+    let item2 = {id: 2};
+    let item3 = {id: 3};
+    let item4 = {id: 4};
+    let item5 = {id: 5};
     linkedList.push(item1);
     linkedList.push(item2);
     linkedList.push(item3);
     linkedList.push(item4);
     linkedList.push(item5);
-    var equals = function(a, b) { return a.id === b.id };
+    let equals = function(a, b) { return a.id === b.id };
     linkedList.remove({id: 3}, equals);
     expect(linkedList.first.data).toBe(item1);
     expect(linkedList.first.next.data).toBe(item2);

--- a/test/data-structures/red-black-tree.spec.js
+++ b/test/data-structures/red-black-tree.spec.js
@@ -1,7 +1,7 @@
-var mod = require('../../src/data-structures/red-black-tree.js');
-var Vertex = mod.Node;
-var RBTree = mod.RBTree;
-var Colors = mod.Colors;
+let mod = require('../../src/data-structures/red-black-tree.js');
+let Vertex = mod.Node;
+let RBTree = mod.RBTree;
+let Colors = mod.Colors;
 
 describe('Node', function () {
   'use strict';
@@ -11,7 +11,7 @@ describe('Node', function () {
   });
 
   it('should set all properties via the constructor', function () {
-    var node = new Vertex('key', 'value', 1, 2, Colors.RED);
+    let node = new Vertex('key', 'value', 1, 2, Colors.RED);
     expect(node.getKey()).toBe('key');
     expect(node.getLeft()).toBe(1);
     expect(node.getRight()).toBe(2);
@@ -21,11 +21,11 @@ describe('Node', function () {
 
   describe('Node flipColor', function () {
     it('should has method flipColor', function () {
-      var node = new Vertex();
+      let node = new Vertex();
       expect(typeof node.flipColor).toBe('function');
     });
     it('should work properly', function () {
-      var node = new Vertex();
+      let node = new Vertex();
       expect(node.isRed()).toBe(false);
       node.flipColor();
       expect(node.isRed()).toBe(true);
@@ -47,14 +47,14 @@ describe('RBTree', function () {
 
   describe('node insertion', function () {
     it('should be able to insert a node in empty tree', function () {
-      var tree = new RBTree();
+      let tree = new RBTree();
       tree.put('foo', 'bar');
       expect(tree._root.getKey()).toBe('foo');
       expect(tree._root.getValue()).toBe('bar');
     });
 
     it('should be able to insert a node in 1 level tree', function () {
-      var tree = new RBTree();
+      let tree = new RBTree();
       tree.put(1, 'bar');
       tree.put(0, 'baz');
       expect(tree._root.getLeft()).not.toBeNull();
@@ -82,7 +82,7 @@ describe('RBTree', function () {
 
   describe('get method', function () {
     it('should be able to find value by given key', function () {
-      var tree = new RBTree();
+      let tree = new RBTree();
       expect(tree.get(1)).toBeUndefined();
       tree.put(1, 'baz');
       expect(tree.get(1)).toBe('baz');
@@ -100,7 +100,7 @@ describe('RBTree', function () {
 
   describe('levelOrderTraversal method', function () {
     it('should be able to traverse tree in level order', function () {
-      var tree = new RBTree();
+      let tree = new RBTree();
       expect(tree.levelOrderTraversal()).toBe('Level Order Traversal -: Tree is empty');
       tree.put(10);
       tree.put(20);

--- a/test/data-structures/segment-tree.spec.js
+++ b/test/data-structures/segment-tree.spec.js
@@ -1,7 +1,7 @@
-var SegmentTree = require('../../src/data-structures/segment-tree.js')
+let SegmentTree = require('../../src/data-structures/segment-tree.js')
   .SegmentTree;
 
-var defaultAggregate = function (a, b) {
+let defaultAggregate = function (a, b) {
   'use strict';
   return Math.min(a, b);
 };
@@ -25,19 +25,19 @@ describe('Segment Tree', function () {
     });
 
     it('should work with empty arrays', function () {
-      var tree = SegmentTree.indexArray([], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([], Infinity, defaultAggregate);
       expect(tree._data).toBeTruthy();
       expect(tree._data.length).toBe(0);
     });
 
     it('should index arrays with one element', function () {
-      var tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
       expect(tree._data).toBeTruthy();
       expect(tree._data.length).toBe(1);
     });
 
     it('should index any array', function () {
-      var tree = SegmentTree.indexArray([1, 2, 3], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([1, 2, 3], Infinity, defaultAggregate);
       expect(tree._data).toEqual([1, 1, 3, 1, 2]);
 
       tree = SegmentTree.indexArray([1, 2, 3, 6], Infinity, defaultAggregate);
@@ -49,7 +49,7 @@ describe('Segment Tree', function () {
   describe('should find the proper value at given interval', function () {
 
     it('should properly find the minimum when in range', function () {
-      var tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
       expect(tree.query(0, 0)).toBe(1);
 
       tree = SegmentTree.indexArray([1, 2], Infinity, defaultAggregate);
@@ -66,7 +66,7 @@ describe('Segment Tree', function () {
     });
 
     it('should properly find the minimum when outside range', function () {
-      var tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
       expect(tree.query(0, 2)).toBe(1);
 
       tree = SegmentTree.indexArray([1, 2, 3], Infinity, defaultAggregate);
@@ -76,7 +76,7 @@ describe('Segment Tree', function () {
     });
 
     it('should throw when the start index is bigger than end', function () {
-      var tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
+      let tree = SegmentTree.indexArray([1], Infinity, defaultAggregate);
       expect(function () {
         tree.query(2, 1);
       }).toThrow();

--- a/test/data-structures/size-balanced-tree.spec.js
+++ b/test/data-structures/size-balanced-tree.spec.js
@@ -1,8 +1,8 @@
-var mod = require('../../src/data-structures/size-balanced-tree.js');
-var Node = mod.Node;
-var Nil = mod.Nil;
-var SBTree = mod.SBTree;
-var updateChild = mod.updateChild;
+let mod = require('../../src/data-structures/size-balanced-tree.js');
+let Node = mod.Node;
+let Nil = mod.Nil;
+let SBTree = mod.SBTree;
+let updateChild = mod.updateChild;
 
 describe('Node', function () {
   'use strict';
@@ -11,7 +11,7 @@ describe('Node', function () {
     expect(typeof Node).toBe('function');
   });
   it('should be a construct properly', function () {
-    var node = new Node(10, Nil, Nil, Nil, 1);
+    let node = new Node(10, Nil, Nil, Nil, 1);
     expect(node.value).toBe(10);
     expect(node.left).toBe(Nil);
     expect(node.right).toBe(Nil);
@@ -19,9 +19,9 @@ describe('Node', function () {
     expect(node.size).toBe(1);
   });
   it('should reference children/parent properly', function () {
-    var root = new Node(10, Nil, Nil, Nil, 1);
-    var left = new Node(5, root, Nil, Nil, 1);
-    var right = new Node(15, root, Nil, Nil, 1);
+    let root = new Node(10, Nil, Nil, Nil, 1);
+    let left = new Node(5, root, Nil, Nil, 1);
+    let right = new Node(15, root, Nil, Nil, 1);
     root.left = left;
     root.right = right;
     expect(root.value).toBe(10);
@@ -48,7 +48,7 @@ describe('SBTree', function () {
     expect(new SBTree()._root).toBe(Nil);
   });
   it('should insert and remove correctly', function () {
-    var sTree = new SBTree();
+    let sTree = new SBTree();
     expect(sTree.size).toBe(0);
     sTree.insert(0, 10);
     expect(sTree.size).toBe(1);
@@ -67,10 +67,10 @@ describe('SBTree', function () {
 
   it('test updateChild', function () {
     checkNil();
-    var root = new Node(10, Nil, Nil, Nil, 1);
-    var left = new Node(5, root, Nil, Nil, 1);
-    var right = new Node(15, root, Nil, Nil, 1);
-    var leftLeft = new Node(10, left, Nil, Nil, 1);
+    let root = new Node(10, Nil, Nil, Nil, 1);
+    let left = new Node(5, root, Nil, Nil, 1);
+    let right = new Node(15, root, Nil, Nil, 1);
+    let leftLeft = new Node(10, left, Nil, Nil, 1);
     left.left = leftLeft;
     left.updateSize();
     root.left = left;
@@ -96,75 +96,75 @@ describe('SBTree', function () {
   }
 
   it('push and get 100000 elements, remove the array by always remove the first/last element', function () {
-    var sTree = new SBTree();
-    for (var i = 0; i < 200000; i += 1) {
+    let sTree = new SBTree();
+    for (let i = 0; i < 200000; i += 1) {
       sTree.push(i);
     }
     checkNil();
-    for (var i = 0; i < 200000; i += 1) {
-      var node = sTree.get(i);
+    for (let i = 0; i < 200000; i += 1) {
+      let node = sTree.get(i);
       expect(node.value).toBe(i);
     }
-    for (var i = 0; i < 200000; i += 1) {
+    for (let i = 0; i < 200000; i += 1) {
       expect(sTree.get(0).value).toBe(i);
-      var node = sTree.remove(0); // Always remove the first element;
+      let node = sTree.remove(0); // Always remove the first element;
       expect(node.value).toBe(i);
     }
     checkNil();
     expect(sTree._root).toBe(Nil);
-    var count = 10000;
-    for (var i = 0; i < count; i += 1) {
+    let count = 10000;
+    for (let i = 0; i < count; i += 1) {
       sTree.insert(0, i);
     }
-    for (var i = 0; i < count; i += 1) {
-      var node = sTree.remove(count - i - 1); // Always remove the last element;
+    for (let i = 0; i < count; i += 1) {
+      let node = sTree.remove(count - i - 1); // Always remove the last element;
       expect(node.value).toBe(i);
       expect(sTree.size).toBe(count - i - 1);
     }
     checkNil();
-    var expectedArray = [];
-    for (var i = 0; i < 100000; i += 1) {
-      var newPos = getRandomIntInclusive(0, sTree.size);
+    let expectedArray = [];
+    for (let i = 0; i < 100000; i += 1) {
+      let newPos = getRandomIntInclusive(0, sTree.size);
       sTree.insert(newPos, i);
       expectedArray.splice(newPos, 0, i);
     }
     expect(sTree.size).toBe(expectedArray.length);
-    for (var i = 0; i < sTree.size; i += 1) {
-      var node = sTree.get(i);
+    for (let i = 0; i < sTree.size; i += 1) {
+      let node = sTree.get(i);
       expect(node.value).toBe(expectedArray[i]);
     }
-    for (var i = 0; i < 90000; i += 1) {
-      var removedPos = getRandomInt(0, sTree.size);
+    for (let i = 0; i < 90000; i += 1) {
+      let removedPos = getRandomInt(0, sTree.size);
       sTree.remove(removedPos);
       expectedArray.splice(removedPos, 1);
     }
-    for (var i = 0; i < sTree.size; i += 1) {
-      var node = sTree.get(i);
+    for (let i = 0; i < sTree.size; i += 1) {
+      let node = sTree.get(i);
       expect(node.value).toBe(expectedArray[i]);
     }
     checkNil();
   });
 
   it('test getIndex', function () {
-    var sTree = new SBTree();
-    for (var i = 0; i < 10000; i += 1) {
-      var key = i.toString();
+    let sTree = new SBTree();
+    for (let i = 0; i < 10000; i += 1) {
+      let key = i.toString();
       sTree.push(key);
     }
 
-    for (var i = 0; i < 100; i += 1) {
-      var item = sTree.get(i);
+    for (let i = 0; i < 100; i += 1) {
+      let item = sTree.get(i);
       expect(item.value).toBe(i.toString());
       expect(sTree.getIndex(item)).toBe(i);
     }
   });
 
   it('test binary search', function () {
-    var sTree = new SBTree();
-    for (var i = 0; i < 10000; i += 1) {
+    let sTree = new SBTree();
+    for (let i = 0; i < 10000; i += 1) {
       sTree.push(i);
     }
-    var cmp = function (a, b) {
+    let cmp = function (a, b) {
       return a - b;
     }
     expect(sTree.binarySearch(cmp, 10.5)).toBe(11)

--- a/test/data-structures/splay-tree.spec.js
+++ b/test/data-structures/splay-tree.spec.js
@@ -1,6 +1,6 @@
-var mod = require('../../src/data-structures/splay-tree.js');
-var Node = mod.Node;
-var SplayTree = mod.SplayTree;
+let mod = require('../../src/data-structures/splay-tree.js');
+let Node = mod.Node;
+let SplayTree = mod.SplayTree;
 
 describe('Node', function () {
   'use strict';
@@ -9,16 +9,16 @@ describe('Node', function () {
     expect(typeof Node).toBe('function');
   });
   it('should be a construct properly', function () {
-    var node = new Node(10, null, null, null);
+    let node = new Node(10, null, null, null);
     expect(node.value).toBe(10);
     expect(node._left).toBe(null);
     expect(node._right).toBe(null);
     expect(node._parent).toBe(null);
   });
   it('should reference children/parent properly', function () {
-    var root = new Node(10, null, null, null);
-    var left = new Node(5, null, null, root);
-    var right = new Node(15, null, null, root);
+    let root = new Node(10, null, null, null);
+    let left = new Node(5, null, null, root);
+    let right = new Node(15, null, null, root);
     root._left = left;
     root._right = right;
     expect(root.value).toBe(10);
@@ -38,13 +38,13 @@ describe('SplayTree', function () {
     expect(new SplayTree()._root).toBe(null);
   });
   it('should insert and remove correctly', function () {
-    var sTree = new SplayTree();
+    let sTree = new SplayTree();
     sTree.insert(10);
     sTree.remove(10);
     expect(sTree._root).toBe(null);
   });
   it('should splay correctly upon inserts', function () {
-    var sTree = new SplayTree();
+    let sTree = new SplayTree();
     sTree.insert(10);
     sTree.insert(5);
     sTree.insert(15);
@@ -55,7 +55,7 @@ describe('SplayTree', function () {
     expect(sTree._root._right.value).toBe(15);
   });
   it('should splay correctly upon search', function () {
-    var sTree = new SplayTree();
+    let sTree = new SplayTree();
     sTree.insert(10);
     sTree.insert(5);
     sTree.insert(15);
@@ -67,7 +67,7 @@ describe('SplayTree', function () {
     expect(sTree._root._right._right.value).toBe(12);
   });
   it('should splay correctly upon remove', function () {
-    var sTree = new SplayTree();
+    let sTree = new SplayTree();
     sTree.insert(10);
     sTree.insert(5);
     sTree.insert(15);

--- a/test/graphics/bezier.spec.js
+++ b/test/graphics/bezier.spec.js
@@ -1,7 +1,7 @@
-var bezier = require('../../src/graphics/bezier');
-var linearBezier = bezier.linearBezier;
-var quadraticBezier = bezier.quadraticBezier;
-var cubicBezier = bezier.cubicBezier;
+let bezier = require('../../src/graphics/bezier');
+let linearBezier = bezier.linearBezier;
+let quadraticBezier = bezier.quadraticBezier;
+let cubicBezier = bezier.cubicBezier;
 
 // see https://www.geogebra.org/m/ek7RHvuc for graphical representation of test values
 

--- a/test/graphics/grapham.spec.js
+++ b/test/graphics/grapham.spec.js
@@ -1,4 +1,4 @@
-var convexHull = require('../../src/graphics/graham').convexHull;
+let convexHull = require('../../src/graphics/graham').convexHull;
 
 const points = [
   { x: 0, y: 0 },

--- a/test/graphs/others/tarjan-connected-components.spec.js
+++ b/test/graphs/others/tarjan-connected-components.spec.js
@@ -1,6 +1,6 @@
-var tj = require('../../../src/graphs/others/tarjan-connected-components').tarjanConnectedComponents;
+let tj = require('../../../src/graphs/others/tarjan-connected-components').tarjanConnectedComponents;
 
-var nonConnected = {
+let nonConnected = {
   v1: [],
   v2: [],
   v3: [],
@@ -8,7 +8,7 @@ var nonConnected = {
   v5: []
 };
 
-var cyclicGraph = {
+let cyclicGraph = {
   v1: ['v2'],
   v2: ['v3'],
   v3: ['v4'],

--- a/test/graphs/others/topological-sort.spec.js
+++ b/test/graphs/others/topological-sort.spec.js
@@ -1,4 +1,4 @@
-var ts = require('../../../src/graphs/others/topological-sort').topologicalSort;
+let ts = require('../../../src/graphs/others/topological-sort').topologicalSort;
 
 describe('Topological sort', function () {
   'use strict';
@@ -12,7 +12,7 @@ describe('Topological sort', function () {
 
   it('should give the proper topological order', function () {
     expect(ts({ v1: [] })).toEqual(['v1']);
-    var graph = {
+    let graph = {
       v1: ['v2'],
       v2: ['v3'],
       v3: []

--- a/test/graphs/searching/bfs.spec.js
+++ b/test/graphs/searching/bfs.spec.js
@@ -1,12 +1,12 @@
 /* jshint multistr: true */
 
-var graph = [[0, 0, 0, 0, 1],
+let graph = [[0, 0, 0, 0, 1],
              [0, 0, 0, 1, 0],
              [0, 0, 0, 0, 0],
              [1, 0, 1, 0, 0],
              [0, 1, 0, 1, 0]];
 
-var bfs = require('../../../src/graphs/searching/bfs').bfs;
+let bfs = require('../../../src/graphs/searching/bfs').bfs;
 
 describe('BFS', function () {
   'use strict';
@@ -25,7 +25,7 @@ describe('BFS', function () {
   });
 
   it('should return falsy value when there\'s no path', function () {
-    var graph = [[0, 0, 0, 0, 1],
+    let graph = [[0, 0, 0, 0, 1],
                  [0, 0, 0, 1, 0],
                  [0, 0, 0, 0, 0],
                  [1, 0, 0, 0, 0],
@@ -44,7 +44,7 @@ describe('BFS', function () {
    *      -> 2
    */
   it('should not update the parent node once set', function () {
-    var graph = [[0, 1, 1],
+    let graph = [[0, 1, 1],
                  [0, 0, 1],
                  [0, 0, 0]];
     expect(bfs(graph, 0, 2)).toEqual([0, 2]);

--- a/test/graphs/searching/dfs.spec.js
+++ b/test/graphs/searching/dfs.spec.js
@@ -1,4 +1,4 @@
-var dfs = require('../../../src/graphs/searching/dfs').dfs;
+let dfs = require('../../../src/graphs/searching/dfs').dfs;
 
 describe('dfs', function () {
   'use strict';

--- a/test/graphs/shortest-path/bellman-ford.spec.js
+++ b/test/graphs/shortest-path/bellman-ford.spec.js
@@ -1,8 +1,8 @@
-var exported =
+let exported =
   require('../../../src/graphs/shortest-path/bellman-ford');
-var bellmanFord = exported.bellmanFord;
-var Vertex = exported.Vertex;
-var Edge = exported.Edge;
+let bellmanFord = exported.bellmanFord;
+let Vertex = exported.Vertex;
+let Edge = exported.Edge;
 
 describe('Bellman-Ford', function () {
   'use strict';
@@ -11,26 +11,26 @@ describe('Bellman-Ford', function () {
   });
 
   it('should work for an empty graph', function () {
-    var vs = [];
-    var e = [];
+    let vs = [];
+    let e = [];
     expect(bellmanFord(vs, e, undefined))
       .toEqual({ parents: {}, distances: {} });
   });
 
   it('should work for a graph with a single vertex', function () {
-    var vs = [new Vertex(1)];
-    var e = [];
+    let vs = [new Vertex(1)];
+    let e = [];
     expect(bellmanFord(vs, e, vs[0]))
       .toEqual({ parents: { 1: null }, distances: { 1: 0 }});
   });
 
   it('should work in the general case', function () {
-    var vs = [new Vertex(1), new Vertex(2), new Vertex(3)];
-    var e = [new Edge(vs[0], vs[1], 2),
+    let vs = [new Vertex(1), new Vertex(2), new Vertex(3)];
+    let e = [new Edge(vs[0], vs[1], 2),
       new Edge(vs[0], vs[2], 10),
       new Edge(vs[1], vs[2], 1)
     ];
-    var output = bellmanFord(vs, e, vs[0]);
+    let output = bellmanFord(vs, e, vs[0]);
     expect(output.distances['3']).toBe(3);
   });
 });

--- a/test/graphs/shortest-path/dijkstra.spec.js
+++ b/test/graphs/shortest-path/dijkstra.spec.js
@@ -1,4 +1,4 @@
-var dijkstra =
+let dijkstra =
   require('../../../src/graphs/shortest-path/dijkstra').dijkstra;
 
 describe('dijkstra', function () {

--- a/test/graphs/spanning-trees/kruskal.spec.js
+++ b/test/graphs/spanning-trees/kruskal.spec.js
@@ -1,4 +1,4 @@
-var kruskal = require('../../../src/graphs/spanning-trees/kruskal');
+let kruskal = require('../../../src/graphs/spanning-trees/kruskal');
 
 describe('Kruskal', function() {
   'use strict';
@@ -12,16 +12,16 @@ describe('Kruskal', function() {
   });
 
   it('should work with an empty graph', function() {
-    var graph = new kruskal.Graph([], 0);
-    var spanningTree = graph.kruskal();
+    let graph = new kruskal.Graph([], 0);
+    let spanningTree = graph.kruskal();
 
     expect(spanningTree.edges.length).toEqual(0);
   });
 
   it('should correctly compute general example', function() {
-    var nodes = [];
-    var edges = [];
-    var i;
+    let nodes = [];
+    let edges = [];
+    let i;
     for (i = 0; i < 7; i += 1) {
       nodes[i] = new kruskal.Vertex(i);
     }
@@ -38,12 +38,12 @@ describe('Kruskal', function() {
     edges.push(new kruskal.Edge(nodes[3], nodes[4], 15));
     edges.push(new kruskal.Edge(nodes[4], nodes[5], 8));
 
-    var graph = new kruskal.Graph(edges);
-    var spanningTree = graph.kruskal();
+    let graph = new kruskal.Graph(edges);
+    let spanningTree = graph.kruskal();
 
     expect(spanningTree.edges.length).toEqual(6);
 
-    var sum = spanningTree.edges.reduce(function(acc, edge) {
+    let sum = spanningTree.edges.reduce(function(acc, edge) {
       return acc += edge.distance;
     }, 0);
 

--- a/test/others/fibonacci.spec.js
+++ b/test/others/fibonacci.spec.js
@@ -1,5 +1,5 @@
-var mod = require('../../src/others/fibonacci.js');
-var fibonacci = mod.fibonacci;
+let mod = require('../../src/others/fibonacci.js');
+let fibonacci = mod.fibonacci;
 
 describe('fibonacci algorithm', function () {
   'use strict';

--- a/test/others/fibonacciMemory.spec.js
+++ b/test/others/fibonacciMemory.spec.js
@@ -1,5 +1,5 @@
-var mod = require('../../src/others/fibonacciMemory.js');
-var fibonacci = mod.fibonacciMemory;
+let mod = require('../../src/others/fibonacciMemory.js');
+let fibonacci = mod.fibonacciMemory;
 
 describe('fibonacci with Memory algorithm', function () {
   'use strict';
@@ -21,7 +21,7 @@ describe('fibonacci with Memory algorithm', function () {
   });
   it('should return value 10 with input 55.', function () {
     expect(fibonacci(10)).toBe(55);
-  });  
+  });
   it('should be 135301852344706760000 with input 98.', function () {
     expect(fibonacci(98)).toBe(135301852344706760000);
   });

--- a/test/others/levenshtein-distance.spec.js
+++ b/test/others/levenshtein-distance.spec.js
@@ -1,5 +1,5 @@
-var mod = require('../../src/others/levenshtein-distance.js');
-var levenshteinDistance = mod.levenshteinDistance;
+let mod = require('../../src/others/levenshtein-distance.js');
+let levenshteinDistance = mod.levenshteinDistance;
 
 describe('Levenstein\'s minimum edit distance algorithm', function () {
   'use strict';

--- a/test/others/min-coins-sum.spec.js
+++ b/test/others/min-coins-sum.spec.js
@@ -1,4 +1,4 @@
-var minCoinsChange =
+let minCoinsChange =
   require('../../src/others/min-coins-change.js').minCoinsChange;
 
 describe('Change making problem', function () {

--- a/test/others/minkowski-distance.spec.js
+++ b/test/others/minkowski-distance.spec.js
@@ -1,5 +1,5 @@
-var mod = require('../../src/others/minkowski-distance.js');
-var minkowskiDistance = mod.minkowskiDistance;
+let mod = require('../../src/others/minkowski-distance.js');
+let minkowskiDistance = mod.minkowskiDistance;
 
 describe('Minkowski Distance', function () {
   'use strict';

--- a/test/primes/is-prime.spec.js
+++ b/test/primes/is-prime.spec.js
@@ -1,4 +1,4 @@
-var isPrime = require('../../src/primes/is-prime').isPrime;
+let isPrime = require('../../src/primes/is-prime').isPrime;
 
 describe('Advanced (optimised) method that checks number on prime', function () {
   'use strict';
@@ -12,8 +12,8 @@ describe('Advanced (optimised) method that checks number on prime', function () 
   });
 
   it('the 10001st prime number should be 104743', function () {
-    var count = 1; //we know that 2 is prime
-    var value = 1;
+    let count = 1; //we know that 2 is prime
+    let value = 1;
 
     while (count < 10001) {
       value += 2;

--- a/test/primes/prime-factor-tree.spec.js
+++ b/test/primes/prime-factor-tree.spec.js
@@ -1,4 +1,4 @@
-var primeFactorTree = require('../../src/primes/prime-factor-tree').primeFactorTree;
+let primeFactorTree = require('../../src/primes/prime-factor-tree').primeFactorTree;
 
 describe('Prime factor tree', function () {
   'use strict';
@@ -18,8 +18,8 @@ describe('Prime factor tree', function () {
   });
 
   it('sum of primes for given number 600851475143 should be 9238', function () {
-    var primes = primeFactorTree(600851475143);
-    var sumOfPrimes = primes.reduce(function (previousValue, currentValue) {
+    let primes = primeFactorTree(600851475143);
+    let sumOfPrimes = primes.reduce(function (previousValue, currentValue) {
       return previousValue + currentValue;
     });
 

--- a/test/primes/sieve-of-atkins.spec.js
+++ b/test/primes/sieve-of-atkins.spec.js
@@ -1,4 +1,4 @@
-var sieveOfAtkins =
+let sieveOfAtkins =
   require('../../src/primes/sieve-of-atkins').sieveOfAtkins;
 
 describe('Sieve Of Atkins', function () {
@@ -16,8 +16,8 @@ describe('Sieve Of Atkins', function () {
   });
 
   it('sum of prime numbers up to 2000000 limit should be 142913828922', function () {
-    var sieve = sieveOfAtkins(2000000);
-    var sumOfPrimes = sieve.reduce(function (previousValue, currentValue) {
+    let sieve = sieveOfAtkins(2000000);
+    let sumOfPrimes = sieve.reduce(function (previousValue, currentValue) {
       return previousValue + currentValue;
     });
 

--- a/test/primes/sieve-of-eratosthenes.spec.js
+++ b/test/primes/sieve-of-eratosthenes.spec.js
@@ -1,4 +1,4 @@
-var sieveOfEratosthenes =
+let sieveOfEratosthenes =
   require('../../src/primes/sieve-of-eratosthenes').sieveOfEratosthenes;
 
 describe('Sieve Of Eratosthenes', function () {
@@ -16,8 +16,8 @@ describe('Sieve Of Eratosthenes', function () {
   });
 
   it('sum of prime numbers up to 2000000 limit should be 142913828922', function () {
-    var sieve = sieveOfEratosthenes(2000000);
-    var sumOfPrimes = sieve.reduce(function (previousValue, currentValue) {
+    let sieve = sieveOfEratosthenes(2000000);
+    let sumOfPrimes = sieve.reduce(function (previousValue, currentValue) {
       return previousValue + currentValue;
     });
 

--- a/test/searching/binarysearch.spec.js
+++ b/test/searching/binarysearch.spec.js
@@ -1,4 +1,4 @@
-var binarySearch =
+let binarySearch =
   require('../../src/searching/binarysearch').binarySearch;
 
 describe('Binary search', function () {
@@ -9,7 +9,7 @@ describe('Binary search', function () {
   });
 
   it('should find the element in position arr.length - 1', function () {
-    var arr = [1, 2, 3, 4, 6, 8];
+    let arr = [1, 2, 3, 4, 6, 8];
     expect(binarySearch(arr, 8)).toBe(arr.length - 1);
   });
 

--- a/test/searching/interpolation-search.spec.js
+++ b/test/searching/interpolation-search.spec.js
@@ -1,4 +1,4 @@
-var interpolationSearch = require('../../src/searching/interpolation-search')
+let interpolationSearch = require('../../src/searching/interpolation-search')
   .interpolationSearch;
 
 describe('Interpolation search', function() {

--- a/test/searching/jump-search.spec.js
+++ b/test/searching/jump-search.spec.js
@@ -1,4 +1,4 @@
-var jumpSearch = require('../../src/searching/jump-search').jumpSearch;
+let jumpSearch = require('../../src/searching/jump-search').jumpSearch;
 
 describe('Jump search', function() {
   'use strict';

--- a/test/searching/knuth-morris-pratt.spec.js
+++ b/test/searching/knuth-morris-pratt.spec.js
@@ -1,4 +1,4 @@
-var indexOf = require('../../src/searching/knuth-morris-pratt').kmp;
+let indexOf = require('../../src/searching/knuth-morris-pratt').kmp;
 
 describe('The string searching algorithm of Knuth-Morris-Pratt', function () {
   'use strict';

--- a/test/searching/linearSearch.spec.js
+++ b/test/searching/linearSearch.spec.js
@@ -1,4 +1,4 @@
-var linearSearch =
+let linearSearch =
   require('../../src/searching/linearSearch').linearSearch;
 
 describe('Linear Search', function () {
@@ -9,7 +9,7 @@ describe('Linear Search', function () {
   });
 
   it('should find the element in position arr.length - 1', function () {
-    var arr = [1, 2, 3, 4, 6, 8];
+    let arr = [1, 2, 3, 4, 6, 8];
     expect(linearSearch(arr, 8)).toBe(arr.length - 1);
   });
 

--- a/test/searching/longest-common-subsequence.spec.js
+++ b/test/searching/longest-common-subsequence.spec.js
@@ -1,4 +1,4 @@
-var longestCommonSubsequence =
+let longestCommonSubsequence =
   require('../../src/searching/' +
     'longest-common-subsequence')
     .longestCommonSubsequence;

--- a/test/searching/longest-increasing-subsequence.spec.js
+++ b/test/searching/longest-increasing-subsequence.spec.js
@@ -1,4 +1,4 @@
-var longestIncreasingSubsequence =
+let longestIncreasingSubsequence =
   require('../../src/searching/' +
     'longest-increasing-subsequence')
     .longestIncreasingSubsequence;
@@ -6,7 +6,7 @@ var longestIncreasingSubsequence =
 describe('longest increasing subsequence', function () {
   'use strict';
 
-  var sequence;
+  let sequence;
   beforeEach(function () {
     sequence = [5, 2, 8, 6, 3, 6, 9, 7, 11];
   });
@@ -16,7 +16,7 @@ describe('longest increasing subsequence', function () {
   });
 
   it('should return the only element in a single element array', function () {
-    var array = [1];
+    let array = [1];
     expect(longestIncreasingSubsequence(array)).toEqual([1]);
   });
 
@@ -34,11 +34,11 @@ describe('longest increasing subsequence', function () {
   });
 
   it('should work with a custom comparator', function () {
-    var cmp = function (a, b) {
+    let cmp = function (a, b) {
       return b - a;
     };
-    var seq = [1, 2, -1];
-    var result = longestIncreasingSubsequence(seq, cmp);
+    let seq = [1, 2, -1];
+    let result = longestIncreasingSubsequence(seq, cmp);
     expect(result.length).toBe(2);
     expect(result).toEqual([1, -1]);
   });

--- a/test/searching/maximum-subarray-divide-and-conquer.spec.js
+++ b/test/searching/maximum-subarray-divide-and-conquer.spec.js
@@ -1,4 +1,4 @@
-var maxSubArray =
+let maxSubArray =
   require('../../src/searching/maximum-subarray-divide-and-conquer')
   .maxSubarray;
 

--- a/test/searching/maximum-subarray.spec.js
+++ b/test/searching/maximum-subarray.spec.js
@@ -1,4 +1,4 @@
-var maxSubArray = require('../../src/searching/maximum-subarray').maxSubarray;
+let maxSubArray = require('../../src/searching/maximum-subarray').maxSubarray;
 
 describe('Maximum subarray', function() {
   'use strict';

--- a/test/searching/quickselect.spec.js
+++ b/test/searching/quickselect.spec.js
@@ -1,4 +1,4 @@
-var quickselect = require('../../src/searching/quickselect').quickselect;
+let quickselect = require('../../src/searching/quickselect').quickselect;
 
 describe('quickselect', function () {
   'use strict';

--- a/test/searching/recursive-binarysearch.spec.js
+++ b/test/searching/recursive-binarysearch.spec.js
@@ -1,4 +1,4 @@
-var binarySearch =
+let binarySearch =
   require('../../src/searching/recursive-binarysearch').binarySearch;
 
 describe('Binary search', function () {

--- a/test/sorting/3-way-string-quicksort.spec.js
+++ b/test/sorting/3-way-string-quicksort.spec.js
@@ -1,4 +1,4 @@
-var quicksort =
+let quicksort =
   require('../../src/sorting/3-way-string-quicksort.js').quicksort;
 
 describe('Most-Significant Digit', function () {
@@ -9,14 +9,14 @@ describe('Most-Significant Digit', function () {
   });
 
   it('should work with arrays with a single element', function () {
-    var arr = ['a'];
+    let arr = ['a'];
     quicksort(arr);
     expect(arr.length).toBe(1);
     expect(arr[0]).toBe('a');
   });
 
   it('should work with arrays with equally length strings', function () {
-    var arr = ['bb', 'aa', 'cc'];
+    let arr = ['bb', 'aa', 'cc'];
     quicksort(arr);
     expect(arr.length).toBe(3);
     expect(arr[0]).toBe('aa');
@@ -25,7 +25,7 @@ describe('Most-Significant Digit', function () {
   });
 
   it('should work with arrays with differently length strings', function () {
-    var arr = ['bb', 'aaa', 'a', 'aa'];
+    let arr = ['bb', 'aaa', 'a', 'aa'];
     quicksort(arr);
     expect(arr.length).toBe(4);
     expect(arr[0]).toBe('a');

--- a/test/sorting/bubblesort.spec.js
+++ b/test/sorting/bubblesort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var bubbleSort =
+let sortTestCase = require('./sort.testcase.js');
+let bubbleSort =
       require('../../src/sorting/bubblesort.js').bubbleSort;
 
 sortTestCase(bubbleSort, 'Bubble sort');

--- a/test/sorting/bucketsort.spec.js
+++ b/test/sorting/bucketsort.spec.js
@@ -1,4 +1,4 @@
-var bs =
+let bs =
   require('../../src/sorting/bucketsort').bucketSort;
 
 describe('bucketsort', function () {

--- a/test/sorting/countingsort.spec.js
+++ b/test/sorting/countingsort.spec.js
@@ -1,4 +1,4 @@
-var cs =
+let cs =
   require('../../src/sorting/countingsort').countingSort;
 
 describe('countingsort', function () {

--- a/test/sorting/heapsort.spec.js
+++ b/test/sorting/heapsort.spec.js
@@ -1,4 +1,4 @@
-var sortTestCase = require('./sort.testcase.js');
-var heapSort = require('../../src/sorting/heapsort.js').heapSort;
+let sortTestCase = require('./sort.testcase.js');
+let heapSort = require('../../src/sorting/heapsort.js').heapSort;
 
 sortTestCase(heapSort, 'Heap sort');

--- a/test/sorting/insertionbinarysort.spec.js
+++ b/test/sorting/insertionbinarysort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var insertionBinarySort =
+let sortTestCase = require('./sort.testcase.js');
+let insertionBinarySort =
       require('../../src/sorting/' +
       'insertion-binary-sort.js').insertionBinarySort;
 

--- a/test/sorting/insertionsort.spec.js
+++ b/test/sorting/insertionsort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var insertionSort = require('../../src/sorting/' +
+let sortTestCase = require('./sort.testcase.js');
+let insertionSort = require('../../src/sorting/' +
       'insertionsort.js').insertionSort;
 
 sortTestCase(insertionSort, 'Insertion sort');

--- a/test/sorting/lsd.spec.js
+++ b/test/sorting/lsd.spec.js
@@ -1,4 +1,4 @@
-var lsd = require('../../src/sorting/lsd.js').lsd;
+let lsd = require('../../src/sorting/lsd.js').lsd;
 
 describe('Least-Significant Digit', function () {
   'use strict';
@@ -8,14 +8,14 @@ describe('Least-Significant Digit', function () {
   });
 
   it('should work with arrays with a single element', function () {
-    var arr = ['a'];
+    let arr = ['a'];
     lsd(arr);
     expect(arr.length).toBe(1);
     expect(arr[0]).toBe('a');
   });
 
   it('should work with arrays with equally length strings', function () {
-    var arr = ['bb', 'aa', 'cc'];
+    let arr = ['bb', 'aa', 'cc'];
     lsd(arr);
     expect(arr.length).toBe(3);
     expect(arr[0]).toBe('aa');
@@ -24,7 +24,7 @@ describe('Least-Significant Digit', function () {
   });
 
   it('should work with arrays with equally length strings', function () {
-    var arr = ['bbb', 'aac', 'aaa'];
+    let arr = ['bbb', 'aac', 'aaa'];
     lsd(arr, 3);
     expect(arr.length).toBe(3);
     expect(arr[0]).toBe('aaa');

--- a/test/sorting/mergesort.spec.js
+++ b/test/sorting/mergesort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var mergeSort =
+let sortTestCase = require('./sort.testcase.js');
+let mergeSort =
       require('../../src/sorting/mergesort.js').mergeSort;
 
 sortTestCase(mergeSort, 'Merge sort');

--- a/test/sorting/msd.spec.js
+++ b/test/sorting/msd.spec.js
@@ -1,4 +1,4 @@
-var msd = require('../../src/sorting/msd.js').msd;
+let msd = require('../../src/sorting/msd.js').msd;
 
 describe('Most-Significant Digit', function () {
   'use strict';
@@ -8,14 +8,14 @@ describe('Most-Significant Digit', function () {
   });
 
   it('should work with arrays with a single element', function () {
-    var arr = ['a'];
+    let arr = ['a'];
     msd(arr);
     expect(arr.length).toBe(1);
     expect(arr[0]).toBe('a');
   });
 
   it('should work with arrays with equally length strings', function () {
-    var arr = ['bb', 'aa', 'cc'];
+    let arr = ['bb', 'aa', 'cc'];
     msd(arr);
     expect(arr.length).toBe(3);
     expect(arr[0]).toBe('aa');
@@ -24,7 +24,7 @@ describe('Most-Significant Digit', function () {
   });
 
   it('should work with arrays with differently length strings', function () {
-    var arr = ['bb', 'aaa', 'a', 'aa'];
+    let arr = ['bb', 'aaa', 'a', 'aa'];
     msd(arr);
     expect(arr.length).toBe(4);
     expect(arr[0]).toBe('a');

--- a/test/sorting/oddeven-sort.spec.js
+++ b/test/sorting/oddeven-sort.spec.js
@@ -1,4 +1,4 @@
-var oes =
+let oes =
   require('../../src/sorting/oddeven-sort').oddEvenSort;
 
 describe('oddeven-sort', function () {

--- a/test/sorting/quicksort-declarative.spec.js
+++ b/test/sorting/quicksort-declarative.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var quickSort =
+let sortTestCase = require('./sort.testcase.js');
+let quickSort =
       require('../../src/sorting/quicksort-declarative.js').quickSort;
 
 sortTestCase(quickSort, 'Quick sort');

--- a/test/sorting/quicksort-middle.spec.js
+++ b/test/sorting/quicksort-middle.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var quickSort =
+let sortTestCase = require('./sort.testcase.js');
+let quickSort =
       require('../../src/sorting/quicksort-middle.js').quickSort;
 
 sortTestCase(quickSort, 'Quick sort');

--- a/test/sorting/quicksort.spec.js
+++ b/test/sorting/quicksort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var quickSort =
+let sortTestCase = require('./sort.testcase.js');
+let quickSort =
       require('../../src/sorting/quicksort.js').quickSort;
 
 sortTestCase(quickSort, 'Quick sort');

--- a/test/sorting/radixsort.spec.js
+++ b/test/sorting/radixsort.spec.js
@@ -1,4 +1,4 @@
-var rx =
+let rx =
       require('../../src/sorting/radixsort.js').radixSort;
 
 describe('radixsort', function () {

--- a/test/sorting/recursiveinsertionsort.spec.js
+++ b/test/sorting/recursiveinsertionsort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var recursiveInsertionSort = require('../../src/sorting/' +
+let sortTestCase = require('./sort.testcase.js');
+let recursiveInsertionSort = require('../../src/sorting/' +
       'recursive-insertionsort.js').recursiveInsertionSort;
 
 sortTestCase(recursiveInsertionSort, 'Recursive insertion sort');

--- a/test/sorting/selectionsort.spec.js
+++ b/test/sorting/selectionsort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var selectionSort =
+let sortTestCase = require('./sort.testcase.js');
+let selectionSort =
       require('../../src/sorting/selectionsort.js')
       .selectionSort;
 

--- a/test/sorting/shellsort.spec.js
+++ b/test/sorting/shellsort.spec.js
@@ -1,5 +1,5 @@
-var sortTestCase = require('./sort.testcase.js');
-var shellSort = require('../../src/sorting/shellsort.js')
+let sortTestCase = require('./sort.testcase.js');
+let shellSort = require('../../src/sorting/shellsort.js')
       .shellSort;
 
 sortTestCase(shellSort, 'Shell sort');

--- a/test/sorting/sort.testcase.js
+++ b/test/sorting/sort.testcase.js
@@ -10,12 +10,12 @@ module.exports = function (sort, algorithmName, options) {
 
     function createRandomArray(config) {
       config = config || {};
-      var size = config.size || 100;
-      var precision = config.precision || 2;
-      var multiplier = config.multiplier || 100;
-      var result = [];
+      let size = config.size || 100;
+      let precision = config.precision || 2;
+      let multiplier = config.multiplier || 100;
+      let result = [];
 
-      for (var i = size; i > 0; i -= 1) {
+      for (let i = size; i > 0; i -= 1) {
         result.push(parseFloat((Math.random() *
             multiplier).toFixed(precision)));
       }
@@ -31,7 +31,7 @@ module.exports = function (sort, algorithmName, options) {
     });
 
     it('should work with random non-sorted arrays', function () {
-      var array;
+      let array;
       if (options.integers) {
         array = createRandomArray();
       } else {
@@ -40,7 +40,7 @@ module.exports = function (sort, algorithmName, options) {
         });
       }
       array = sort(array);
-      for (var i = 0; i < array.length - 1; i += 1) {
+      for (let i = 0; i < array.length - 1; i += 1) {
         expect(array[i] <= array[i + 1]).toBeTruthy();
       }
     });
@@ -52,10 +52,10 @@ module.exports = function (sort, algorithmName, options) {
           return b - a;
         }
 
-        var array = createRandomArray();
+        let array = createRandomArray();
         array = sort(array, comparator);
 
-        for (var i = 0; i < array.length - 1; i += 1) {
+        for (let i = 0; i < array.length - 1; i += 1) {
           expect(array[i] >= array[i + 1]).toBeTruthy();
         }
       });


### PR DESCRIPTION
This PR begin the process of moving to ES6 syntax (which has been discussed in #194 ).

This PR achieves 3 things as part of fix:
# 1. Adds an explicit eslint script command to the package file.
The rationale behind this was so that the eslint rules could be tweaked to favour ES6 syntax. With an explicit linting script in place we can more easily identify where changes need to occur.  

# 2. Change lint rule to use `let` / `const`
As raised in #194, let / const sytanx should be favoured. The linting rules have been changed to flag `vars`, and the issues have been fixed.

# 3. Fix previous linting errors
This repository was breaking its own linting rules, such as `no-plus-plus`. These have been resolved.

**Note:** I do not believe that this totally resolves #194 and that should remain open; this PR does, however, begin that journey should make the journey easier.